### PR TITLE
Adds automated release pipeline

### DIFF
--- a/.env.release.example
+++ b/.env.release.example
@@ -1,0 +1,15 @@
+LEDGERRA_VERSION=v0.1.0
+LEDGERRA_IMAGE_REGISTRY=ghcr.io
+LEDGERRA_IMAGE_NAMESPACE=your-github-owner-or-org
+LEDGERRA_HTTP_PORT=8080
+LEDGERRA_POSTGRES_DATA=./postgres
+
+POSTGRES_DB=ledgerra
+POSTGRES_USER=ledgerra
+POSTGRES_PASSWORD=replace-with-a-long-random-password
+
+AUTH_ISSUER=Ledgerra
+AUTH_AUDIENCE=Ledgerra.Clients
+AUTH_SIGNING_KEY=replace-with-at-least-32-random-characters
+AUTH_ACCESS_TOKEN_MINUTES=60
+AUTH_REFRESH_TOKEN_DAYS=30

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,162 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*.*.*"
+
+permissions:
+  contents: write
+  packages: write
+
+concurrency:
+  group: release-${{ github.ref }}
+  cancel-in-progress: false
+
+env:
+  DOTNET_VERSION: 10.0.x
+  NODE_VERSION: 22
+
+jobs:
+  backend:
+    name: Backend checks
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: backend
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: ${{ env.DOTNET_VERSION }}
+
+      - name: Restore
+        run: dotnet restore Ledgerra.sln
+
+      - name: Build
+        run: dotnet build Ledgerra.sln --configuration Release --no-restore
+
+      - name: Test
+        run: dotnet test Ledgerra.sln --configuration Release --no-build --verbosity normal
+
+  frontend:
+    name: Frontend checks
+    runs-on: ubuntu-latest
+
+    defaults:
+      run:
+        working-directory: frontend
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Test
+        run: npm test
+
+      - name: Build
+        run: npm run build
+
+  docker:
+    name: Build and publish images
+    runs-on: ubuntu-latest
+    needs:
+      - backend
+      - frontend
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: backend
+            image: ledgerra-backend
+            dockerfile: backend/Dockerfile
+          - name: frontend
+            image: ledgerra-frontend
+            dockerfile: frontend/Dockerfile
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Prepare image metadata
+        id: image
+        run: |
+          owner="$(echo "${GITHUB_REPOSITORY_OWNER}" | tr '[:upper:]' '[:lower:]')"
+          image="ghcr.io/${owner}/${{ matrix.image }}"
+          {
+            echo "name=${image}"
+            echo "tag=${GITHUB_REF_NAME}"
+          } >> "${GITHUB_OUTPUT}"
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push ${{ matrix.name }} image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ${{ matrix.dockerfile }}
+          push: true
+          platforms: linux/amd64,linux/arm64
+          build-args: |
+            VITE_API_BASE_URL=/api
+          tags: |
+            ${{ steps.image.outputs.name }}:${{ steps.image.outputs.tag }}
+            ${{ steps.image.outputs.name }}:latest
+          labels: |
+            org.opencontainers.image.source=${{ github.server_url }}/${{ github.repository }}
+            org.opencontainers.image.revision=${{ github.sha }}
+            org.opencontainers.image.version=${{ steps.image.outputs.tag }}
+
+  github-release:
+    name: Create GitHub release
+    runs-on: ubuntu-latest
+    needs:
+      - docker
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Prepare release assets
+        run: |
+          mkdir -p release-assets
+          cp docker-compose.release.yml release-assets/docker-compose.yml
+          cp .env.release.example release-assets/env.example
+          owner="$(echo "${GITHUB_REPOSITORY_OWNER}" | tr '[:upper:]' '[:lower:]')"
+          sed -i "s/^LEDGERRA_VERSION=.*/LEDGERRA_VERSION=${GITHUB_REF_NAME}/" release-assets/env.example
+          sed -i "s/^LEDGERRA_IMAGE_NAMESPACE=.*/LEDGERRA_IMAGE_NAMESPACE=${owner}/" release-assets/env.example
+
+      - name: Publish GitHub release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true
+          files: |
+            release-assets/docker-compose.yml
+            release-assets/env.example

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 # dotenv files
 .env
 .env.*
+!.env.release.example
 .worktrees/
 frontend/node_modules/
 frontend/dist/

--- a/README.md
+++ b/README.md
@@ -129,6 +129,66 @@ Before production use, change:
 - `POSTGRES_PASSWORD`
 - any public-facing reverse proxy or TLS configuration
 
+### Release Builds
+
+Tagged releases publish ready-to-run Docker images to GitHub Container Registry
+and attach deployment assets to the GitHub Release. This is the recommended path
+for Unraid OS, TrueNAS SCALE, and Linux hosts because the target machine only
+needs Docker Compose and does not need to build Ledgerra from source.
+
+To publish a release, create and push a semantic version tag:
+
+```bash
+git tag v0.1.0
+git push origin v0.1.0
+```
+
+The release workflow runs backend and frontend checks, builds multi-architecture
+Linux images for `amd64` and `arm64`, pushes them to GHCR, and creates a GitHub
+Release. The published image names are:
+
+```text
+ghcr.io/<github-owner>/ledgerra-backend:<tag>
+ghcr.io/<github-owner>/ledgerra-frontend:<tag>
+```
+
+The same images are also tagged as `latest`.
+
+For release deployment, download these assets from the matching GitHub Release:
+
+- `docker-compose.yml`
+- `env.example`
+
+Then prepare the host:
+
+```bash
+mkdir -p ledgerra
+cd ledgerra
+cp env.example .env
+```
+
+Edit `.env` before first start:
+
+- set `POSTGRES_PASSWORD` to a long random password
+- set `AUTH_SIGNING_KEY` to at least 32 random characters
+- confirm `LEDGERRA_VERSION` matches the release tag
+- change `LEDGERRA_HTTP_PORT` if the host already uses port `8080`
+- change `LEDGERRA_POSTGRES_DATA` to a NAS-friendly appdata path if needed
+
+Start Ledgerra:
+
+```bash
+docker compose pull
+docker compose up -d
+```
+
+Upgrade to a newer release by changing `LEDGERRA_VERSION` in `.env`, then run:
+
+```bash
+docker compose pull
+docker compose up -d
+```
+
 ### Unraid OS Setup
 
 Ledgerra can run on Unraid with the Docker Compose Manager plugin or from the
@@ -143,30 +203,23 @@ Unraid terminal with Docker Compose.
    mkdir -p /mnt/user/appdata/ledgerra/postgres
    ```
 
-3. Copy this repository's `docker-compose.yml` to
-   `/mnt/user/appdata/ledgerra/docker-compose.yml`.
-4. Edit `/mnt/user/appdata/ledgerra/docker-compose.yml` before first start:
+3. Download the release `docker-compose.yml` and `env.example` from the GitHub
+   Release, then place them in `/mnt/user/appdata/ledgerra`. Rename
+   `env.example` to `.env`.
+4. Edit `/mnt/user/appdata/ledgerra/.env` before first start:
 
-   - Change `POSTGRES_PASSWORD`.
-   - Use the same password in `ConnectionStrings__Ledgerra`.
-   - Replace `Auth__SigningKey` with a long random secret.
-   - Change the frontend port mapping if Unraid already uses `8080`, for
-     example `8088:80`.
-   - For Unraid-friendly backups, replace the `postgres` volume mapping with:
-
-     ```yaml
-     volumes:
-       - /mnt/user/appdata/ledgerra/postgres:/var/lib/postgresql/data
-     ```
-
-     If you use this bind mount, remove the top-level `volumes:` block for the
-     named `ledgerra-postgres` volume.
+   - Change `POSTGRES_PASSWORD` in `.env`.
+   - Replace `AUTH_SIGNING_KEY` in `.env` with a long random secret.
+   - Change `LEDGERRA_HTTP_PORT` if Unraid already uses `8080`.
+   - Set `LEDGERRA_POSTGRES_DATA=/mnt/user/appdata/ledgerra/postgres` for
+     Unraid-friendly backups.
 
 5. Start Ledgerra:
 
    ```bash
    cd /mnt/user/appdata/ledgerra
-   docker compose up --build -d
+   docker compose pull
+   docker compose up -d
    ```
 
 6. Open Ledgerra at `http://<unraid-server-ip>:8080`, or the alternate host
@@ -177,7 +230,7 @@ Useful maintenance commands:
 ```bash
 cd /mnt/user/appdata/ledgerra
 docker compose pull
-docker compose up --build -d
+docker compose up -d
 docker compose logs -f
 docker compose down
 ```

--- a/docker-compose.release.yml
+++ b/docker-compose.release.yml
@@ -1,0 +1,43 @@
+services:
+  postgres:
+    image: postgres:17-alpine
+    container_name: ledgerra-postgres
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB:-ledgerra}
+      POSTGRES_USER: ${POSTGRES_USER:-ledgerra}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?Set POSTGRES_PASSWORD in .env}
+    volumes:
+      - ${LEDGERRA_POSTGRES_DATA:-./postgres}:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${POSTGRES_USER:-ledgerra} -d ${POSTGRES_DB:-ledgerra}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  backend:
+    image: ${LEDGERRA_IMAGE_REGISTRY:-ghcr.io}/${LEDGERRA_IMAGE_NAMESPACE:?Set LEDGERRA_IMAGE_NAMESPACE in .env}/ledgerra-backend:${LEDGERRA_VERSION:-latest}
+    container_name: ledgerra-backend
+    restart: unless-stopped
+    environment:
+      ASPNETCORE_ENVIRONMENT: Production
+      ConnectionStrings__Ledgerra: Host=postgres;Port=5432;Database=${POSTGRES_DB:-ledgerra};Username=${POSTGRES_USER:-ledgerra};Password=${POSTGRES_PASSWORD}
+      Auth__Issuer: ${AUTH_ISSUER:-Ledgerra}
+      Auth__Audience: ${AUTH_AUDIENCE:-Ledgerra.Clients}
+      Auth__SigningKey: ${AUTH_SIGNING_KEY:?Set AUTH_SIGNING_KEY in .env}
+      Auth__AccessTokenMinutes: ${AUTH_ACCESS_TOKEN_MINUTES:-60}
+      Auth__RefreshTokenDays: ${AUTH_REFRESH_TOKEN_DAYS:-30}
+    depends_on:
+      postgres:
+        condition: service_healthy
+    expose:
+      - "8080"
+
+  frontend:
+    image: ${LEDGERRA_IMAGE_REGISTRY:-ghcr.io}/${LEDGERRA_IMAGE_NAMESPACE:?Set LEDGERRA_IMAGE_NAMESPACE in .env}/ledgerra-frontend:${LEDGERRA_VERSION:-latest}
+    container_name: ledgerra-frontend
+    restart: unless-stopped
+    depends_on:
+      - backend
+    ports:
+      - "${LEDGERRA_HTTP_PORT:-8080}:80"


### PR DESCRIPTION
Sets up a GitHub Actions workflow that triggers on semantic version tags (`v*.*.*`):
- Automates backend and frontend checks, multi-architecture Docker image builds (amd64, arm64), and publishing to GitHub Container Registry.
- Creates GitHub releases with pre-configured `docker-compose.yml` and `env.example` assets, streamlining deployment.
- Updates the `README.md` with clear, simplified instructions for deploying and upgrading release builds using Docker Compose.
- Introduces dedicated `docker-compose.release.yml` and `.env.release.example` files to support the new deployment method.