### PR TITLE
Add compact settings layout design and implementation plan

### DIFF
--- a/docs/plans/2026-05-03-settings-compact-layout-design.md
+++ b/docs/plans/2026-05-03-settings-compact-layout-design.md
@@ -1,0 +1,57 @@
+# Settings View Compact Layout Design
+
+**Date:** 2026-05-03
+**Issue:** LOW-5 — Improve settings view design
+**Branch:** low-5-improve-settings-view-design
+
+## Problem
+
+The settings page renders 5 SectionCards in a single vertical stack at full content width (up to 1440px). This causes excessive scrolling and visually spread-out elements.
+
+## Solution
+
+Use the existing `split-grid` CSS class to pair smaller sections side-by-side in a two-column layout. The Import Rules section stays full-width since it contains an inline multi-field form and a data table that benefit from horizontal space.
+
+## Layout
+
+```
+page-stack
+├── PageHeader (full width)
+├── split-grid (row 1)
+│   ├── SectionCard: Appearance
+│   └── SectionCard: Regional Preferences
+├── split-grid (row 2)
+│   ├── SectionCard: AI Providers
+│   └── SectionCard: Current Session
+└── SectionCard: Import Rules (full width)
+```
+
+## Changes required
+
+### SettingsPage.tsx
+
+Wrap pairs of SectionCards in `<div className="split-grid">` divs:
+
+- Row 1: Appearance + Regional Preferences
+- Row 2: AI Providers + Current Session
+- Import Rules stays unwrapped (full width)
+
+### CSS (styles.css)
+
+No new CSS needed. The `split-grid` class already provides:
+
+- `display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 0.9rem; align-items: start;`
+- Collapses to single column at 1180px breakpoint
+
+## Responsive behavior
+
+- **>1180px:** Two-column grid rows
+- **<=1180px:** Falls back to single column (existing breakpoint)
+- **<=620px:** Form internals collapse (existing behavior)
+
+## What doesn't change
+
+- All form logic, handlers, state management
+- SectionCard component
+- Import Rules section layout
+- All existing responsive breakpoints

--- a/docs/plans/2026-05-03-settings-compact-layout-design.md
+++ b/docs/plans/2026-05-03-settings-compact-layout-design.md
@@ -1,57 +1,92 @@
-# Settings View Compact Layout Design
+# Settings Compact Layout Implementation Plan
 
-**Date:** 2026-05-03
-**Issue:** LOW-5 — Improve settings view design
-**Branch:** low-5-improve-settings-view-design
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
 
-## Problem
+**Goal:** Make the settings page more compact by pairing sections side-by-side in a two-column grid layout.
 
-The settings page renders 5 SectionCards in a single vertical stack at full content width (up to 1440px). This causes excessive scrolling and visually spread-out elements.
+**Architecture:** Wrap pairs of existing `SectionCard` components in `<div className="split-grid">` wrappers inside `SettingsPage.tsx`. The `split-grid` CSS class already exists and handles responsive collapse. Import Rules stays full-width.
 
-## Solution
+**Tech Stack:** React, CSS (custom properties), Vitest + React Testing Library
 
-Use the existing `split-grid` CSS class to pair smaller sections side-by-side in a two-column layout. The Import Rules section stays full-width since it contains an inline multi-field form and a data table that benefit from horizontal space.
+---
 
-## Layout
+### Task 1: Update SettingsPage layout to two-column grid
 
+**Files:**
+- Modify: `frontend/src/pages/SettingsPage.tsx:176-410` (JSX return block)
+
+**Step 1: Wrap Appearance + Regional Preferences in split-grid**
+
+In `SettingsPage.tsx`, find the return statement (line 176). After the `<PageHeader>` component, wrap the first two `<SectionCard>` components (Appearance and Regional Preferences) in a `<div className="split-grid">`:
+
+```tsx
+<div className="split-grid">
+  <SectionCard title={t("settings.appearance")}>
+    {/* existing Appearance content unchanged */}
+  </SectionCard>
+
+  <SectionCard title={t("settings.regionalPreferences")}>
+    {/* existing Regional Preferences content unchanged */}
+  </SectionCard>
+</div>
 ```
-page-stack
-├── PageHeader (full width)
-├── split-grid (row 1)
-│   ├── SectionCard: Appearance
-│   └── SectionCard: Regional Preferences
-├── split-grid (row 2)
-│   ├── SectionCard: AI Providers
-│   └── SectionCard: Current Session
-└── SectionCard: Import Rules (full width)
+
+**Step 2: Wrap AI Providers + Current Session in split-grid**
+
+Wrap the AI Providers `<SectionCard>` and Current Session `<SectionCard>` in a second `<div className="split-grid">`:
+
+```tsx
+<div className="split-grid">
+  <SectionCard title={t("settings.aiProviders")}>
+    {/* existing AI Providers content unchanged */}
+  </SectionCard>
+
+  <SectionCard title={t("settings.currentSession")}>
+    {/* existing Current Session content unchanged */}
+  </SectionCard>
+</div>
 ```
 
-## Changes required
+**Step 3: Leave Import Rules unwrapped**
 
-### SettingsPage.tsx
+The Import Rules `<SectionCard>` stays as-is (no wrapper div), keeping it full-width.
 
-Wrap pairs of SectionCards in `<div className="split-grid">` divs:
+Final structure of the return block:
+```tsx
+<div className="page-stack">
+  <PageHeader ... />
+  <div className="split-grid">
+    <SectionCard title="Appearance">...</SectionCard>
+    <SectionCard title="Regional Preferences">...</SectionCard>
+  </div>
+  <div className="split-grid">
+    <SectionCard title="AI Providers">...</SectionCard>
+    <SectionCard title="Current Session">...</SectionCard>
+  </div>
+  <SectionCard title="Import Rules">...</SectionCard>
+</div>
+```
 
-- Row 1: Appearance + Regional Preferences
-- Row 2: AI Providers + Current Session
-- Import Rules stays unwrapped (full width)
+**Step 4: Run existing tests**
 
-### CSS (styles.css)
+Run: `cd frontend && npx vitest run src/pages/SettingsPage.test.tsx`
+Expected: All 9 tests PASS (tests query by text/role, not DOM structure)
 
-No new CSS needed. The `split-grid` class already provides:
+**Step 5: Run type check**
 
-- `display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 0.9rem; align-items: start;`
-- Collapses to single column at 1180px breakpoint
+Run: `cd frontend && npx tsc --noEmit`
+Expected: No errors
 
-## Responsive behavior
+**Step 6: Visual verification**
 
-- **>1180px:** Two-column grid rows
-- **<=1180px:** Falls back to single column (existing breakpoint)
-- **<=620px:** Form internals collapse (existing behavior)
+Start dev server and verify in browser:
+- Desktop (>1180px): sections appear in two-column pairs
+- Narrow window (<=1180px): falls back to single column
+- Mobile (<=620px): form internals collapse
 
-## What doesn't change
+**Step 7: Commit**
 
-- All form logic, handlers, state management
-- SectionCard component
-- Import Rules section layout
-- All existing responsive breakpoints
+```bash
+git add frontend/src/pages/SettingsPage.tsx
+git commit -m "Use two-column grid layout for settings page (LOW-5)"
+```

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -181,56 +181,59 @@ export function SettingsPage() {
         description={t("settings.description")}
       />
 
-      <SectionCard title={t("settings.appearance")}>
-        <form className="stack-form" onSubmit={(event) => event.preventDefault()}>
-          <label>
-            {t("settings.theme")}
-            <select
-              value={themePreference}
-              onChange={(event) => setThemePreference(event.target.value as ThemePreference)}
-            >
-              <option value="system">{t("settings.themeSystem")}</option>
-              <option value="light">{t("settings.themeLight")}</option>
-              <option value="dark">{t("settings.themeDark")}</option>
-            </select>
-          </label>
-          <p className="helper-text">
-            {t("settings.themeDescription", {
-              theme: resolvedTheme === "dark" ? t("settings.themeDark").toLowerCase() : t("settings.themeLight").toLowerCase()
-            })}
-          </p>
-        </form>
-      </SectionCard>
+      <div className="split-grid">
+        <SectionCard title={t("settings.appearance")}>
+          <form className="stack-form" onSubmit={(event) => event.preventDefault()}>
+            <label>
+              {t("settings.theme")}
+              <select
+                value={themePreference}
+                onChange={(event) => setThemePreference(event.target.value as ThemePreference)}
+              >
+                <option value="system">{t("settings.themeSystem")}</option>
+                <option value="light">{t("settings.themeLight")}</option>
+                <option value="dark">{t("settings.themeDark")}</option>
+              </select>
+            </label>
+            <p className="helper-text">
+              {t("settings.themeDescription", {
+                theme: resolvedTheme === "dark" ? t("settings.themeDark").toLowerCase() : t("settings.themeLight").toLowerCase()
+              })}
+            </p>
+          </form>
+        </SectionCard>
 
-      <SectionCard title={t("settings.regionalPreferences")}>
-        <form className="stack-form" onSubmit={handleSubmit}>
-          <label>
-            {t("settings.preferredCurrency")}
-            <select value={preferredCurrencyCode} onChange={(event) => setPreferredCurrencyCode(event.target.value)}>
-              {supportedCurrencies.map((currency) => (
-                <option key={currency.code} value={currency.code}>
-                  {currency.label}
-                </option>
-              ))}
-            </select>
-          </label>
-          <label>
-            {t("settings.preferredLanguage")}
-            <select value={preferredLanguageCode} onChange={(event) => setPreferredLanguageCode(event.target.value)}>
-              {supportedLanguages.map((language) => (
-                <option key={language.code} value={language.code}>
-                  {language.label}
-                </option>
-              ))}
-            </select>
-          </label>
-          <button className="primary-button" type="submit">
-            {t("settings.savePreferences")}
-          </button>
-        </form>
-      </SectionCard>
+        <SectionCard title={t("settings.regionalPreferences")}>
+          <form className="stack-form" onSubmit={handleSubmit}>
+            <label>
+              {t("settings.preferredCurrency")}
+              <select value={preferredCurrencyCode} onChange={(event) => setPreferredCurrencyCode(event.target.value)}>
+                {supportedCurrencies.map((currency) => (
+                  <option key={currency.code} value={currency.code}>
+                    {currency.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <label>
+              {t("settings.preferredLanguage")}
+              <select value={preferredLanguageCode} onChange={(event) => setPreferredLanguageCode(event.target.value)}>
+                {supportedLanguages.map((language) => (
+                  <option key={language.code} value={language.code}>
+                    {language.label}
+                  </option>
+                ))}
+              </select>
+            </label>
+            <button className="primary-button" type="submit">
+              {t("settings.savePreferences")}
+            </button>
+          </form>
+        </SectionCard>
+      </div>
 
-      <SectionCard title={t("settings.aiProviders")}>
+      <div className="split-grid">
+        <SectionCard title={t("settings.aiProviders")}>
         <form className="stack-form" onSubmit={handleAiProviderSubmit}>
           {aiProviderError ? <p className="error-banner">{aiProviderError}</p> : null}
           <label>
@@ -306,7 +309,48 @@ export function SettingsPage() {
             </div>
           </article>
         </div>
-      </SectionCard>
+        </SectionCard>
+
+        <SectionCard title={t("settings.currentSession")}>
+          <div className="table-list">
+            <article className="table-row">
+              <div>
+                <strong>{t("settings.userEmail")}</strong>
+                <p>{t("settings.activeLocalAccount")}</p>
+              </div>
+              <strong>{profile?.email ?? auth?.email ?? t("common.unknown")}</strong>
+            </article>
+            <article className="table-row">
+              <div>
+                <strong>{t("settings.mainCurrency")}</strong>
+                <p>{t("settings.appWideTotals")}</p>
+              </div>
+              <strong>{profile?.preferredCurrencyCode ?? "USD"}</strong>
+            </article>
+            <article className="table-row">
+              <div>
+                <strong>{t("settings.preferredLanguage")}</strong>
+                <p>{t("settings.languageAndFormatting")}</p>
+              </div>
+              <strong>{supportedLanguages.find((language) => language.code === (profile?.preferredLanguageCode ?? preferredLanguageCode))?.label ?? preferredLanguageCode.toUpperCase()}</strong>
+            </article>
+            <article className="table-row">
+              <div>
+                <strong>{t("settings.apiModel")}</strong>
+                <p>{t("settings.singleUserJwt")}</p>
+              </div>
+              <strong>{t("settings.v1Ready")}</strong>
+            </article>
+            <article className="table-row">
+              <div>
+                <strong>{t("settings.mobileReadiness")}</strong>
+                <p>{t("settings.mobileReadinessDescription")}</p>
+              </div>
+              <strong>{t("settings.prepared")}</strong>
+            </article>
+          </div>
+        </SectionCard>
+      </div>
 
       <SectionCard title={t("settings.importRules")}>
         <form className="stack-form rule-form" onSubmit={handleRuleSubmit}>
@@ -365,46 +409,6 @@ export function SettingsPage() {
               </article>
             ))
           )}
-        </div>
-      </SectionCard>
-
-      <SectionCard title={t("settings.currentSession")}>
-        <div className="table-list">
-          <article className="table-row">
-            <div>
-              <strong>{t("settings.userEmail")}</strong>
-              <p>{t("settings.activeLocalAccount")}</p>
-            </div>
-            <strong>{profile?.email ?? auth?.email ?? t("common.unknown")}</strong>
-          </article>
-          <article className="table-row">
-            <div>
-              <strong>{t("settings.mainCurrency")}</strong>
-              <p>{t("settings.appWideTotals")}</p>
-            </div>
-            <strong>{profile?.preferredCurrencyCode ?? "USD"}</strong>
-          </article>
-          <article className="table-row">
-            <div>
-              <strong>{t("settings.preferredLanguage")}</strong>
-              <p>{t("settings.languageAndFormatting")}</p>
-            </div>
-            <strong>{supportedLanguages.find((language) => language.code === (profile?.preferredLanguageCode ?? preferredLanguageCode))?.label ?? preferredLanguageCode.toUpperCase()}</strong>
-          </article>
-          <article className="table-row">
-            <div>
-              <strong>{t("settings.apiModel")}</strong>
-              <p>{t("settings.singleUserJwt")}</p>
-            </div>
-            <strong>{t("settings.v1Ready")}</strong>
-          </article>
-          <article className="table-row">
-            <div>
-              <strong>{t("settings.mobileReadiness")}</strong>
-              <p>{t("settings.mobileReadinessDescription")}</p>
-            </div>
-            <strong>{t("settings.prepared")}</strong>
-          </article>
         </div>
       </SectionCard>
     </div>


### PR DESCRIPTION
This pull request updates the layout of the settings page to use a more compact, two-column grid arrangement for better usability and visual clarity. The changes group related settings side-by-side while keeping the Import Rules section full-width. The implementation follows a clear plan and ensures existing tests and type checks pass.

**Settings page layout improvements:**

* Wrapped the Appearance and Regional Preferences sections in a `<div className="split-grid">` to display them side-by-side in a two-column layout.
* Wrapped the AI Providers and Current Session sections in a second `<div className="split-grid">` for a two-column layout, and moved the Current Session section from its previous full-width position into this grid. [[1]](diffhunk://#diff-39a34da300f0b475678a216600cdbb808c114ad0898e0d1f3d97185cf7b5e432R233-R235) [[2]](diffhunk://#diff-39a34da300f0b475678a216600cdbb808c114ad0898e0d1f3d97185cf7b5e432R314-R354) [[3]](diffhunk://#diff-39a34da300f0b475678a216600cdbb808c114ad0898e0d1f3d97185cf7b5e432L370-L409)
* Left the Import Rules section as a full-width row, outside of any grid wrapper, to maintain its prominence.

**Documentation and implementation plan:**

* Added a detailed implementation plan in `docs/plans/2026-05-03-settings-compact-layout-design.md`, outlining the steps, file locations, test commands, and expected results for this layout update.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added design documentation for settings page layout optimization plan.

* **Refactor**
  * Reorganized settings page layout with a two-column grid to display "Appearance," "Regional Preferences," "AI Providers," and "Current Session" sections in a more compact arrangement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->