### PR TITLE
Add recurring transaction templates and generation API

### DIFF
--- a/backend/src/Ledgerra.Api/Contracts/RecurringTransactionContracts.cs
+++ b/backend/src/Ledgerra.Api/Contracts/RecurringTransactionContracts.cs
@@ -1,0 +1,26 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Ledgerra.Api.Contracts;
+
+public sealed class CreateRecurringTransactionTemplateRequest
+{
+    [Required] public Guid AccountId { get; init; }
+    public Guid? CategoryId { get; init; }
+    [Range(0.01, 999999999)] public decimal Amount { get; init; }
+    [Required] public string Type { get; init; } = string.Empty;
+    [Required] public string Interval { get; init; } = string.Empty;
+    [Required] public DateTime StartOnUtc { get; init; }
+    [MaxLength(400)] public string? Note { get; init; }
+}
+
+public sealed record RecurringTransactionTemplateResponse(
+    Guid Id,
+    Guid AccountId,
+    Guid? CategoryId,
+    decimal Amount,
+    string Type,
+    string Interval,
+    DateTime StartOnUtc,
+    DateTime? LastGeneratedOnUtc,
+    bool IsActive,
+    string? Note);

--- a/backend/src/Ledgerra.Api/Controllers/RecurringTransactionsController.cs
+++ b/backend/src/Ledgerra.Api/Controllers/RecurringTransactionsController.cs
@@ -1,0 +1,40 @@
+using Ledgerra.Api.Contracts;
+using Ledgerra.Api.Extensions;
+using Ledgerra.Application.Transactions;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Ledgerra.Api.Controllers;
+
+[ApiController]
+[Authorize]
+[Route("api/recurring-transactions")]
+public sealed class RecurringTransactionsController : ControllerBase
+{
+    private readonly RecurringTransactionUseCases _useCases;
+    public RecurringTransactionsController(RecurringTransactionUseCases useCases) => _useCases = useCases;
+
+    [HttpGet]
+    public async Task<ActionResult<IReadOnlyList<RecurringTransactionTemplateResponse>>> GetAll(CancellationToken cancellationToken)
+    {
+        var items = await _useCases.GetAllAsync(User.GetRequiredUserId(), cancellationToken);
+        return Ok(items.Select(Map));
+    }
+
+    [HttpPost]
+    public async Task<ActionResult<RecurringTransactionTemplateResponse>> Create(CreateRecurringTransactionTemplateRequest request, CancellationToken cancellationToken)
+    {
+        var item = await _useCases.CreateAsync(User.GetRequiredUserId(), request.AccountId, request.CategoryId, request.Amount, request.Type, request.Interval, request.StartOnUtc, request.Note, cancellationToken);
+        return Ok(Map(item));
+    }
+
+    [HttpPost("generate")]
+    public async Task<ActionResult<object>> Generate(CancellationToken cancellationToken)
+    {
+        var count = await _useCases.GenerateDueAsync(User.GetRequiredUserId(), DateTime.UtcNow, cancellationToken);
+        return Ok(new { generated = count });
+    }
+
+    private static RecurringTransactionTemplateResponse Map(Ledgerra.Domain.Transactions.RecurringTransactionTemplate item)
+        => new(item.Id, item.AccountId, item.CategoryId, item.Amount, item.Type.ToString(), item.Interval.ToString(), item.StartOnUtc, item.LastGeneratedOnUtc, item.IsActive, item.Note);
+}

--- a/backend/src/Ledgerra.Api/Controllers/RecurringTransactionsController.cs
+++ b/backend/src/Ledgerra.Api/Controllers/RecurringTransactionsController.cs
@@ -24,8 +24,15 @@ public sealed class RecurringTransactionsController : ControllerBase
     [HttpPost]
     public async Task<ActionResult<RecurringTransactionTemplateResponse>> Create(CreateRecurringTransactionTemplateRequest request, CancellationToken cancellationToken)
     {
-        var item = await _useCases.CreateAsync(User.GetRequiredUserId(), request.AccountId, request.CategoryId, request.Amount, request.Type, request.Interval, request.StartOnUtc, request.Note, cancellationToken);
-        return Ok(Map(item));
+        try
+        {
+            var item = await _useCases.CreateAsync(User.GetRequiredUserId(), request.AccountId, request.CategoryId, request.Amount, request.Type, request.Interval, request.StartOnUtc, request.Note, cancellationToken);
+            return Ok(Map(item));
+        }
+        catch (InvalidOperationException ex)
+        {
+            return BadRequest(new { error = ex.Message });
+        }
     }
 
     [HttpPost("generate")]

--- a/backend/src/Ledgerra.Api/Program.cs
+++ b/backend/src/Ledgerra.Api/Program.cs
@@ -65,6 +65,7 @@ builder.Services.AddScoped<UpdateProfileCommandHandler>();
 builder.Services.AddScoped<UpdateTransactionCommandHandler>();
 builder.Services.AddScoped<GetTransactionByIdQueryHandler>();
 builder.Services.AddScoped<GetTransactionsQueryHandler>();
+builder.Services.AddScoped<IRecurringTransactionRepository, RecurringTransactionRepository>();
 builder.Services.AddScoped<RecurringTransactionUseCases>();
 builder.Services.AddScoped<IBudgetSummaryStore, BudgetSummaryStore>();
 builder.Services.AddScoped<IDashboardSummaryDataProvider, DashboardSummaryDataProvider>();

--- a/backend/src/Ledgerra.Api/Program.cs
+++ b/backend/src/Ledgerra.Api/Program.cs
@@ -65,6 +65,7 @@ builder.Services.AddScoped<UpdateProfileCommandHandler>();
 builder.Services.AddScoped<UpdateTransactionCommandHandler>();
 builder.Services.AddScoped<GetTransactionByIdQueryHandler>();
 builder.Services.AddScoped<GetTransactionsQueryHandler>();
+builder.Services.AddScoped<RecurringTransactionUseCases>();
 builder.Services.AddScoped<IBudgetSummaryStore, BudgetSummaryStore>();
 builder.Services.AddScoped<IDashboardSummaryDataProvider, DashboardSummaryDataProvider>();
 builder.Services.AddScoped<IReportingDataProvider, ReportingDataProvider>();

--- a/backend/src/Ledgerra.Application/Transactions/RecurringTransactionUseCases.cs
+++ b/backend/src/Ledgerra.Application/Transactions/RecurringTransactionUseCases.cs
@@ -2,8 +2,21 @@ using Ledgerra.Domain.Transactions;
 
 namespace Ledgerra.Application.Transactions;
 
+public interface IRecurringTransactionRepository
+{
+    Task<IReadOnlyList<RecurringTransactionTemplate>> GetAllAsync(Guid userId, CancellationToken ct);
+    Task<RecurringTransactionTemplate> CreateAsync(RecurringTransactionTemplate template, CancellationToken ct);
+    Task<bool> AccountExistsAsync(Guid userId, Guid accountId, CancellationToken ct);
+    Task<bool> CategoryExistsAsync(Guid userId, Guid categoryId, CancellationToken ct);
+    Task<IReadOnlyList<RecurringTransactionTemplate>> GetActiveTemplatesAsync(Guid userId, CancellationToken ct);
+    Task AddTransactionAsync(Transaction transaction, CancellationToken ct);
+    Task SaveChangesAsync(CancellationToken ct);
+    Task<T> ExecuteInSerializableTransactionAsync<T>(Func<Task<T>> action, CancellationToken ct);
+}
+
 public sealed class RecurringTransactionUseCases
 {
+    private const int MaxCatchUpPerTemplate = 100;
     private readonly IRecurringTransactionRepository _repository;
 
     public RecurringTransactionUseCases(IRecurringTransactionRepository repository) => _repository = repository;
@@ -40,21 +53,45 @@ public sealed class RecurringTransactionUseCases
             var generated = 0;
             foreach (var template in templates)
             {
+                var catchUpCount = 0;
                 var next = template.LastGeneratedOnUtc ?? template.StartOnUtc;
                 if (template.LastGeneratedOnUtc.HasValue)
                 {
-                    next = template.Interval == RecurringInterval.Weekly ? next.AddDays(7) : next.AddMonths(1);
+                    next = template.Interval == RecurringInterval.Weekly
+                        ? next.AddDays(7)
+                        : GetNextAnchoredMonthlyOccurrence(template.StartOnUtc, next);
                 }
-                while (next <= nowUtc)
+                while (next <= nowUtc && catchUpCount < MaxCatchUpPerTemplate)
                 {
                     await _repository.AddTransactionAsync(new Transaction { Id = Guid.NewGuid(), UserId = userId, AccountId = template.AccountId, CategoryId = template.CategoryId, Amount = template.Amount, Type = template.Type, OccurredOnUtc = next, Note = template.Note }, ct);
                     template.LastGeneratedOnUtc = next;
                     generated++;
-                    next = template.Interval == RecurringInterval.Weekly ? next.AddDays(7) : next.AddMonths(1);
+                    catchUpCount++;
+                    next = template.Interval == RecurringInterval.Weekly
+                        ? next.AddDays(7)
+                        : GetNextAnchoredMonthlyOccurrence(template.StartOnUtc, next);
                 }
             }
             await _repository.SaveChangesAsync(ct);
             return generated;
         }, ct);
+    }
+
+    private static DateTime GetNextAnchoredMonthlyOccurrence(DateTime startOnUtc, DateTime previousOccurrenceUtc)
+    {
+        // Compute next month/year from previous occurrence
+        var year = previousOccurrenceUtc.Year;
+        var month = previousOccurrenceUtc.Month + 1;
+        if (month > 12)
+        {
+            month = 1;
+            year++;
+        }
+
+        // Anchor to the original day from startOnUtc, clamped to valid days in target month
+        var day = Math.Min(startOnUtc.Day, DateTime.DaysInMonth(year, month));
+
+        // Preserve the time components from startOnUtc
+        return new DateTime(year, month, day, startOnUtc.Hour, startOnUtc.Minute, startOnUtc.Second, DateTimeKind.Utc);
     }
 }

--- a/backend/src/Ledgerra.Application/Transactions/RecurringTransactionUseCases.cs
+++ b/backend/src/Ledgerra.Application/Transactions/RecurringTransactionUseCases.cs
@@ -1,0 +1,53 @@
+using Ledgerra.Domain.Transactions;
+using Microsoft.EntityFrameworkCore;
+using Ledgerra.Infrastructure.Persistence;
+
+namespace Ledgerra.Application.Transactions;
+
+public sealed class RecurringTransactionUseCases
+{
+    private readonly LedgerraDbContext _db;
+
+    public RecurringTransactionUseCases(LedgerraDbContext db) => _db = db;
+
+    public async Task<IReadOnlyList<RecurringTransactionTemplate>> GetAllAsync(Guid userId, CancellationToken ct)
+        => await _db.RecurringTransactionTemplates.Where(x => x.UserId == userId).OrderBy(x => x.StartOnUtc).ToListAsync(ct);
+
+    public async Task<RecurringTransactionTemplate> CreateAsync(Guid userId, Guid accountId, Guid? categoryId, decimal amount, string type, string interval, DateTime startOnUtc, string? note, CancellationToken ct)
+    {
+        if (startOnUtc.Kind != DateTimeKind.Utc) throw new InvalidOperationException("StartOnUtc must be UTC");
+        if (!Enum.TryParse<TransactionType>(type, true, out var txType) || (txType != TransactionType.Expense && txType != TransactionType.Income)) throw new InvalidOperationException("Type must be Income or Expense");
+        if (!Enum.TryParse<RecurringInterval>(interval, true, out var parsedInterval)) throw new InvalidOperationException("Interval must be Weekly or Monthly");
+
+        var item = new RecurringTransactionTemplate
+        {
+            Id = Guid.NewGuid(), UserId = userId, AccountId = accountId, CategoryId = categoryId, Amount = amount, Type = txType, Interval = parsedInterval, StartOnUtc = startOnUtc, Note = note
+        };
+        _db.RecurringTransactionTemplates.Add(item);
+        await _db.SaveChangesAsync(ct);
+        return item;
+    }
+
+    public async Task<int> GenerateDueAsync(Guid userId, DateTime nowUtc, CancellationToken ct)
+    {
+        var templates = await _db.RecurringTransactionTemplates.Where(x => x.UserId == userId && x.IsActive).ToListAsync(ct);
+        var generated = 0;
+        foreach (var template in templates)
+        {
+            var next = template.LastGeneratedOnUtc ?? template.StartOnUtc;
+            if (template.LastGeneratedOnUtc.HasValue)
+            {
+                next = template.Interval == RecurringInterval.Weekly ? next.AddDays(7) : next.AddMonths(1);
+            }
+            while (next <= nowUtc)
+            {
+                _db.Transactions.Add(new Transaction { Id = Guid.NewGuid(), UserId = userId, AccountId = template.AccountId, CategoryId = template.CategoryId, Amount = template.Amount, Type = template.Type, OccurredOnUtc = next, Note = template.Note });
+                template.LastGeneratedOnUtc = next;
+                generated++;
+                next = template.Interval == RecurringInterval.Weekly ? next.AddDays(7) : next.AddMonths(1);
+            }
+        }
+        await _db.SaveChangesAsync(ct);
+        return generated;
+    }
+}

--- a/backend/src/Ledgerra.Application/Transactions/RecurringTransactionUseCases.cs
+++ b/backend/src/Ledgerra.Application/Transactions/RecurringTransactionUseCases.cs
@@ -1,17 +1,15 @@
 using Ledgerra.Domain.Transactions;
-using Microsoft.EntityFrameworkCore;
-using Ledgerra.Infrastructure.Persistence;
 
 namespace Ledgerra.Application.Transactions;
 
 public sealed class RecurringTransactionUseCases
 {
-    private readonly LedgerraDbContext _db;
+    private readonly IRecurringTransactionRepository _repository;
 
-    public RecurringTransactionUseCases(LedgerraDbContext db) => _db = db;
+    public RecurringTransactionUseCases(IRecurringTransactionRepository repository) => _repository = repository;
 
     public async Task<IReadOnlyList<RecurringTransactionTemplate>> GetAllAsync(Guid userId, CancellationToken ct)
-        => await _db.RecurringTransactionTemplates.Where(x => x.UserId == userId).OrderBy(x => x.StartOnUtc).ToListAsync(ct);
+        => await _repository.GetAllAsync(userId, ct);
 
     public async Task<RecurringTransactionTemplate> CreateAsync(Guid userId, Guid accountId, Guid? categoryId, decimal amount, string type, string interval, DateTime startOnUtc, string? note, CancellationToken ct)
     {
@@ -19,35 +17,44 @@ public sealed class RecurringTransactionUseCases
         if (!Enum.TryParse<TransactionType>(type, true, out var txType) || (txType != TransactionType.Expense && txType != TransactionType.Income)) throw new InvalidOperationException("Type must be Income or Expense");
         if (!Enum.TryParse<RecurringInterval>(interval, true, out var parsedInterval)) throw new InvalidOperationException("Interval must be Weekly or Monthly");
 
+        // Verify account ownership
+        if (!await _repository.AccountExistsAsync(userId, accountId, ct))
+            throw new InvalidOperationException("Account not found or does not belong to user");
+
+        // Verify category ownership if provided
+        if (categoryId.HasValue && !await _repository.CategoryExistsAsync(userId, categoryId.Value, ct))
+            throw new InvalidOperationException("Category not found or does not belong to user");
+
         var item = new RecurringTransactionTemplate
         {
             Id = Guid.NewGuid(), UserId = userId, AccountId = accountId, CategoryId = categoryId, Amount = amount, Type = txType, Interval = parsedInterval, StartOnUtc = startOnUtc, Note = note
         };
-        _db.RecurringTransactionTemplates.Add(item);
-        await _db.SaveChangesAsync(ct);
-        return item;
+        return await _repository.CreateAsync(item, ct);
     }
 
     public async Task<int> GenerateDueAsync(Guid userId, DateTime nowUtc, CancellationToken ct)
     {
-        var templates = await _db.RecurringTransactionTemplates.Where(x => x.UserId == userId && x.IsActive).ToListAsync(ct);
-        var generated = 0;
-        foreach (var template in templates)
+        return await _repository.ExecuteInSerializableTransactionAsync(async () =>
         {
-            var next = template.LastGeneratedOnUtc ?? template.StartOnUtc;
-            if (template.LastGeneratedOnUtc.HasValue)
+            var templates = await _repository.GetActiveTemplatesAsync(userId, ct);
+            var generated = 0;
+            foreach (var template in templates)
             {
-                next = template.Interval == RecurringInterval.Weekly ? next.AddDays(7) : next.AddMonths(1);
+                var next = template.LastGeneratedOnUtc ?? template.StartOnUtc;
+                if (template.LastGeneratedOnUtc.HasValue)
+                {
+                    next = template.Interval == RecurringInterval.Weekly ? next.AddDays(7) : next.AddMonths(1);
+                }
+                while (next <= nowUtc)
+                {
+                    await _repository.AddTransactionAsync(new Transaction { Id = Guid.NewGuid(), UserId = userId, AccountId = template.AccountId, CategoryId = template.CategoryId, Amount = template.Amount, Type = template.Type, OccurredOnUtc = next, Note = template.Note }, ct);
+                    template.LastGeneratedOnUtc = next;
+                    generated++;
+                    next = template.Interval == RecurringInterval.Weekly ? next.AddDays(7) : next.AddMonths(1);
+                }
             }
-            while (next <= nowUtc)
-            {
-                _db.Transactions.Add(new Transaction { Id = Guid.NewGuid(), UserId = userId, AccountId = template.AccountId, CategoryId = template.CategoryId, Amount = template.Amount, Type = template.Type, OccurredOnUtc = next, Note = template.Note });
-                template.LastGeneratedOnUtc = next;
-                generated++;
-                next = template.Interval == RecurringInterval.Weekly ? next.AddDays(7) : next.AddMonths(1);
-            }
-        }
-        await _db.SaveChangesAsync(ct);
-        return generated;
+            await _repository.SaveChangesAsync(ct);
+            return generated;
+        }, ct);
     }
 }

--- a/backend/src/Ledgerra.Domain/Transactions/RecurringInterval.cs
+++ b/backend/src/Ledgerra.Domain/Transactions/RecurringInterval.cs
@@ -1,0 +1,7 @@
+namespace Ledgerra.Domain.Transactions;
+
+public enum RecurringInterval
+{
+    Weekly = 1,
+    Monthly = 2
+}

--- a/backend/src/Ledgerra.Domain/Transactions/RecurringTransactionTemplate.cs
+++ b/backend/src/Ledgerra.Domain/Transactions/RecurringTransactionTemplate.cs
@@ -1,0 +1,16 @@
+namespace Ledgerra.Domain.Transactions;
+
+public sealed class RecurringTransactionTemplate
+{
+    public Guid Id { get; set; }
+    public Guid UserId { get; set; }
+    public Guid AccountId { get; set; }
+    public Guid? CategoryId { get; set; }
+    public decimal Amount { get; set; }
+    public TransactionType Type { get; set; }
+    public RecurringInterval Interval { get; set; }
+    public DateTime StartOnUtc { get; set; }
+    public DateTime? LastGeneratedOnUtc { get; set; }
+    public bool IsActive { get; set; } = true;
+    public string? Note { get; set; }
+}

--- a/backend/src/Ledgerra.Infrastructure/Persistence/LedgerraDbContext.cs
+++ b/backend/src/Ledgerra.Infrastructure/Persistence/LedgerraDbContext.cs
@@ -114,11 +114,19 @@ public sealed class LedgerraDbContext : DbContext
             builder.Property(template => template.Note).HasMaxLength(400);
             builder.Property(template => template.Type).HasConversion<string>().HasMaxLength(32);
             builder.Property(template => template.Interval).HasConversion<string>().HasMaxLength(32);
-            builder.HasIndex(template => new { template.UserId, template.IsActive });
+            builder.HasIndex(template => new { template.UserId, template.AccountId, template.CategoryId, template.IsActive });
             builder.HasOne<AppUser>()
                 .WithMany()
                 .HasForeignKey(template => template.UserId)
                 .OnDelete(DeleteBehavior.Cascade);
+            builder.HasOne<Account>()
+                .WithMany()
+                .HasForeignKey(template => template.AccountId)
+                .OnDelete(DeleteBehavior.Restrict);
+            builder.HasOne<Category>()
+                .WithMany()
+                .HasForeignKey(template => template.CategoryId)
+                .OnDelete(DeleteBehavior.Restrict);
         });
 
         modelBuilder.Entity<BudgetPeriod>(builder =>

--- a/backend/src/Ledgerra.Infrastructure/Persistence/LedgerraDbContext.cs
+++ b/backend/src/Ledgerra.Infrastructure/Persistence/LedgerraDbContext.cs
@@ -26,6 +26,8 @@ public sealed class LedgerraDbContext : DbContext
 
     public DbSet<Transaction> Transactions => Set<Transaction>();
 
+    public DbSet<RecurringTransactionTemplate> RecurringTransactionTemplates => Set<RecurringTransactionTemplate>();
+
     public DbSet<BudgetPeriod> BudgetPeriods => Set<BudgetPeriod>();
 
     public DbSet<BudgetCategoryLimit> BudgetCategoryLimits => Set<BudgetCategoryLimit>();
@@ -102,6 +104,21 @@ public sealed class LedgerraDbContext : DbContext
                 .WithMany(category => category.Transactions)
                 .HasForeignKey(transaction => transaction.CategoryId)
                 .OnDelete(DeleteBehavior.SetNull);
+        });
+
+
+        modelBuilder.Entity<RecurringTransactionTemplate>(builder =>
+        {
+            builder.HasKey(template => template.Id);
+            builder.Property(template => template.Amount).HasPrecision(18, 2);
+            builder.Property(template => template.Note).HasMaxLength(400);
+            builder.Property(template => template.Type).HasConversion<string>().HasMaxLength(32);
+            builder.Property(template => template.Interval).HasConversion<string>().HasMaxLength(32);
+            builder.HasIndex(template => new { template.UserId, template.IsActive });
+            builder.HasOne<AppUser>()
+                .WithMany()
+                .HasForeignKey(template => template.UserId)
+                .OnDelete(DeleteBehavior.Cascade);
         });
 
         modelBuilder.Entity<BudgetPeriod>(builder =>

--- a/backend/src/Ledgerra.Infrastructure/Persistence/RecurringTransactionRepository.cs
+++ b/backend/src/Ledgerra.Infrastructure/Persistence/RecurringTransactionRepository.cs
@@ -1,0 +1,67 @@
+using Ledgerra.Application.Transactions;
+using Ledgerra.Domain.Transactions;
+using Microsoft.EntityFrameworkCore;
+
+namespace Ledgerra.Infrastructure.Persistence;
+
+public sealed class RecurringTransactionRepository : IRecurringTransactionRepository
+{
+    private readonly LedgerraDbContext _dbContext;
+
+    public RecurringTransactionRepository(LedgerraDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public async Task<IReadOnlyList<RecurringTransactionTemplate>> GetAllAsync(Guid userId, CancellationToken ct)
+    {
+        return await _dbContext.RecurringTransactionTemplates
+            .Where(item => item.UserId == userId)
+            .OrderBy(item => item.StartOnUtc)
+            .ToListAsync(ct);
+    }
+
+    public async Task<RecurringTransactionTemplate> CreateAsync(RecurringTransactionTemplate template, CancellationToken ct)
+    {
+        _dbContext.RecurringTransactionTemplates.Add(template);
+        await _dbContext.SaveChangesAsync(ct);
+        return template;
+    }
+
+    public Task<bool> AccountExistsAsync(Guid userId, Guid accountId, CancellationToken ct)
+    {
+        return _dbContext.Accounts.AnyAsync(item => item.UserId == userId && item.Id == accountId, ct);
+    }
+
+    public Task<bool> CategoryExistsAsync(Guid userId, Guid categoryId, CancellationToken ct)
+    {
+        return _dbContext.Categories.AnyAsync(item => item.UserId == userId && item.Id == categoryId, ct);
+    }
+
+    public async Task<IReadOnlyList<RecurringTransactionTemplate>> GetActiveTemplatesAsync(Guid userId, CancellationToken ct)
+    {
+        return await _dbContext.RecurringTransactionTemplates
+            .Where(item => item.UserId == userId && item.IsActive)
+            .OrderBy(item => item.StartOnUtc)
+            .ToListAsync(ct);
+    }
+
+    public Task AddTransactionAsync(Transaction transaction, CancellationToken ct)
+    {
+        _dbContext.Transactions.Add(transaction);
+        return Task.CompletedTask;
+    }
+
+    public Task SaveChangesAsync(CancellationToken ct)
+    {
+        return _dbContext.SaveChangesAsync(ct);
+    }
+
+    public async Task<T> ExecuteInSerializableTransactionAsync<T>(Func<Task<T>> action, CancellationToken ct)
+    {
+        await using var transaction = await _dbContext.Database.BeginTransactionAsync(System.Data.IsolationLevel.Serializable, ct);
+        var result = await action();
+        await transaction.CommitAsync(ct);
+        return result;
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide first-class support for recurring transactions (rent, subscriptions, utilities) by defining templates that can auto-generate ledger entries on a schedule.
- Expose a minimal API surface to create/list templates and to run a catch-up generation pass that emits due `Transaction` records.

### Description
- Added domain types `RecurringTransactionTemplate` and `RecurringInterval` in `backend/src/Ledgerra.Domain/Transactions` to model templates (amount, account, category, type, interval, schedule tracking, active flag, note).
- Extended `LedgerraDbContext` with `DbSet<RecurringTransactionTemplate>` and EF Core configuration for precision, max lengths, enum conversions, indexes and FK to `AppUser`.
- Implemented `RecurringTransactionUseCases` with `GetAllAsync`, `CreateAsync` (validation of UTC/tokens/type/interval) and `GenerateDueAsync` which creates catch-up transactions for `Weekly` and `Monthly` intervals up to the provided UTC time.
- Added API contracts (`CreateRecurringTransactionTemplateRequest`, `RecurringTransactionTemplateResponse`) and a new authenticated controller `RecurringTransactionsController` exposing `GET /api/recurring-transactions`, `POST /api/recurring-transactions`, and `POST /api/recurring-transactions/generate`.
- Registered `RecurringTransactionUseCases` in DI and wired the new persistence model into migrations/`OnModelCreating`.

### Testing
- Attempted to run `dotnet build backend/Ledgerra.sln`, but `dotnet` is not available in the execution environment so the build could not be executed.
- No automated tests were run in this environment due to the missing SDK; changes were validated via local static inspection and compilation was not performed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f78b3dcfcc83249cabcdc546ab76e9)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Recurring transaction templates (weekly/monthly) with start date, optional category and note, amount, and active flag.
  * Endpoints to create, list, and trigger generation of recurring transactions.
  * Automatic generation of transactions from active templates with last-generated tracking and catch-up behavior.
  * Input validations for required fields, amount range, and note length.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->