### PR TITLE
LOW-14: Add advanced, URL-shareable transaction filters

### DIFF
--- a/frontend/src/pages/TransactionsPage.test.tsx
+++ b/frontend/src/pages/TransactionsPage.test.tsx
@@ -67,6 +67,7 @@ vi.mock("../hooks/useLedgerraData", () => ({
 describe("TransactionsPage", () => {
   beforeEach(() => {
     cleanup();
+    window.history.replaceState(null, "", "/transactions");
     vi.clearAllMocks();
     mocks.getTransactions.mockResolvedValue([
       {

--- a/frontend/src/pages/TransactionsPage.test.tsx
+++ b/frontend/src/pages/TransactionsPage.test.tsx
@@ -105,11 +105,13 @@ describe("TransactionsPage", () => {
 
     render(<TransactionsPage />);
 
-    await user.selectOptions(screen.getByLabelText("Filter by account"), "account-1");
-    await user.selectOptions(screen.getByLabelText("Filter by category"), "category-1");
+    await user.selectOptions(screen.getByLabelText("Filter by account"), ["account-1"]);
+    await user.selectOptions(screen.getByLabelText("Filter by category"), ["category-1"]);
     await user.selectOptions(screen.getByLabelText("Filter by type"), "Expense");
     fireEvent.change(screen.getByLabelText("From date"), { target: { value: "2026-04-01" } });
     fireEvent.change(screen.getByLabelText("To date"), { target: { value: "2026-04-30" } });
+    fireEvent.change(screen.getByLabelText("Min amount"), { target: { value: "10" } });
+    fireEvent.change(screen.getByLabelText("Max amount"), { target: { value: "100" } });
     await user.type(screen.getByLabelText("Search notes"), "market");
 
     await waitFor(() => {
@@ -121,6 +123,11 @@ describe("TransactionsPage", () => {
 
     expect(screen.getByText("Market")).toBeInTheDocument();
     expect(screen.queryByText("Payroll")).not.toBeInTheDocument();
+    expect(window.location.search).toContain("accountId=account-1");
+    expect(window.location.search).toContain("categoryId=category-1");
+    expect(window.location.search).toContain("minAmount=10");
+    expect(window.location.search).toContain("maxAmount=100");
+    expect(window.location.search).toContain("q=market");
   });
 
   test("edits a transaction from the ledger", async () => {

--- a/frontend/src/pages/TransactionsPage.tsx
+++ b/frontend/src/pages/TransactionsPage.tsx
@@ -35,13 +35,16 @@ export function TransactionsPage() {
   const [formMode, setFormMode] = useState<TransactionFormMode>("create");
   const [editingTransactionId, setEditingTransactionId] = useState<string | null>(null);
   const [formValues, setFormValues] = useState<Partial<TransactionFormValues>>({});
-  const [filterAccountId, setFilterAccountId] = useState("");
-  const [filterCategoryId, setFilterCategoryId] = useState("");
-  const [filterType, setFilterType] = useState("");
-  const [fromDate, setFromDate] = useState("");
-  const [toDate, setToDate] = useState("");
-  const [noteSearch, setNoteSearch] = useState("");
-  const [showUncategorizedOnly, setShowUncategorizedOnly] = useState(() => new URLSearchParams(window.location.search).get("view") === "uncategorized");
+  const initialQuery = useMemo(() => new URLSearchParams(window.location.search), []);
+  const [filterAccountIds, setFilterAccountIds] = useState<string[]>(() => initialQuery.getAll("accountId"));
+  const [filterCategoryIds, setFilterCategoryIds] = useState<string[]>(() => initialQuery.getAll("categoryId"));
+  const [filterType, setFilterType] = useState(() => initialQuery.get("type") ?? "");
+  const [fromDate, setFromDate] = useState(() => initialQuery.get("from") ?? "");
+  const [toDate, setToDate] = useState(() => initialQuery.get("to") ?? "");
+  const [minAmount, setMinAmount] = useState(() => initialQuery.get("minAmount") ?? "");
+  const [maxAmount, setMaxAmount] = useState(() => initialQuery.get("maxAmount") ?? "");
+  const [noteSearch, setNoteSearch] = useState(() => initialQuery.get("q") ?? "");
+  const [showUncategorizedOnly, setShowUncategorizedOnly] = useState(() => initialQuery.get("view") === "uncategorized");
   const [ledgerTransactions, setLedgerTransactions] = useState<Transaction[]>(transactions);
   const [statusMessage, setStatusMessage] = useState("");
   const [errorMessage, setErrorMessage] = useState("");
@@ -52,11 +55,11 @@ export function TransactionsPage() {
 
   const filterQuery = useMemo(() => {
     const params = new URLSearchParams();
-    if (filterAccountId) {
-      params.set("accountId", filterAccountId);
+    if (filterAccountIds.length === 1) {
+      params.set("accountId", filterAccountIds[0]);
     }
-    if (filterCategoryId && filterType !== "Transfer") {
-      params.set("categoryId", filterCategoryId);
+    if (filterCategoryIds.length === 1 && filterType !== "Transfer") {
+      params.set("categoryId", filterCategoryIds[0]);
     }
     if (filterType && filterType !== "Transfer") {
       params.set("type", filterType);
@@ -70,7 +73,24 @@ export function TransactionsPage() {
 
     const query = params.toString();
     return query ? `?${query}` : "";
-  }, [filterAccountId, filterCategoryId, filterType, fromDate, toDate]);
+  }, [filterAccountIds, filterCategoryIds, filterType, fromDate, toDate]);
+
+  useEffect(() => {
+    const params = new URLSearchParams();
+    filterAccountIds.forEach((id) => params.append("accountId", id));
+    if (filterType !== "Transfer") {
+      filterCategoryIds.forEach((id) => params.append("categoryId", id));
+    }
+    if (filterType) params.set("type", filterType);
+    if (fromDate) params.set("from", fromDate);
+    if (toDate) params.set("to", toDate);
+    if (minAmount) params.set("minAmount", minAmount);
+    if (maxAmount) params.set("maxAmount", maxAmount);
+    if (noteSearch.trim()) params.set("q", noteSearch.trim());
+    if (showUncategorizedOnly) params.set("view", "uncategorized");
+    const query = params.toString();
+    window.history.replaceState(null, "", query ? `?${query}` : window.location.pathname);
+  }, [filterAccountIds, filterCategoryIds, filterType, fromDate, toDate, minAmount, maxAmount, noteSearch, showUncategorizedOnly]);
 
   const loadTransactions = useCallback(async () => {
     if (!auth?.accessToken) {
@@ -92,8 +112,22 @@ export function TransactionsPage() {
 
   const visibleTransactions = useMemo(() => {
     const normalizedSearch = noteSearch.trim().toLowerCase();
+    const min = minAmount ? Number(minAmount) : null;
+    const max = maxAmount ? Number(maxAmount) : null;
     return ledgerTransactions.filter((transaction) => {
       if (filterType === "Transfer" && !transaction.type.startsWith("Transfer")) {
+        return false;
+      }
+      if (filterAccountIds.length > 0 && !filterAccountIds.includes(transaction.accountId)) {
+        return false;
+      }
+      if (filterType !== "Transfer" && filterCategoryIds.length > 0 && !filterCategoryIds.includes(transaction.categoryId ?? "")) {
+        return false;
+      }
+      if (min !== null && transaction.amount < min) {
+        return false;
+      }
+      if (max !== null && transaction.amount > max) {
         return false;
       }
 
@@ -107,7 +141,7 @@ export function TransactionsPage() {
 
       return (transaction.note ?? "").toLowerCase().includes(normalizedSearch);
     });
-  }, [filterType, ledgerTransactions, noteSearch, showUncategorizedOnly]);
+  }, [filterType, filterAccountIds, filterCategoryIds, ledgerTransactions, minAmount, maxAmount, noteSearch, showUncategorizedOnly]);
 
   const expenseCategories = useMemo(
     () => categories.filter((category) => category.kind === "Expense"),
@@ -259,8 +293,7 @@ export function TransactionsPage() {
           <div className="transaction-filters">
             <label>
               {t("transactions.filterByAccount")}
-              <select value={filterAccountId} onChange={(event) => setFilterAccountId(event.target.value)}>
-                <option value="">{t("common.allAccounts")}</option>
+              <select multiple value={filterAccountIds} onChange={(event) => setFilterAccountIds(Array.from(event.target.selectedOptions, (option) => option.value))}>
                 {accounts.map((account) => (
                   <option key={account.id} value={account.id}>
                     {account.name}
@@ -270,8 +303,12 @@ export function TransactionsPage() {
             </label>
             <label>
               {t("transactions.filterByCategory")}
-              <select value={filterCategoryId} onChange={(event) => setFilterCategoryId(event.target.value)} disabled={filterType === "Transfer"}>
-                <option value="">{t("common.allCategories")}</option>
+              <select
+                multiple
+                value={filterCategoryIds}
+                onChange={(event) => setFilterCategoryIds(Array.from(event.target.selectedOptions, (option) => option.value))}
+                disabled={filterType === "Transfer"}
+              >
                 {categories.map((category) => (
                   <option key={category.id} value={category.id}>
                     {category.name}
@@ -301,6 +338,14 @@ export function TransactionsPage() {
             <label>
               {t("transactions.searchNotes")}
               <input value={noteSearch} onChange={(event) => setNoteSearch(event.target.value)} placeholder={t("transactions.searchPlaceholder")} />
+            </label>
+            <label>
+              Min amount
+              <input value={minAmount} onChange={(event) => setMinAmount(event.target.value)} type="number" step="0.01" />
+            </label>
+            <label>
+              Max amount
+              <input value={maxAmount} onChange={(event) => setMaxAmount(event.target.value)} type="number" step="0.01" />
             </label>
             <label className="inline-checkbox">
               <input


### PR DESCRIPTION
### Motivation

- Provide a persistent, shareable filter bar for the transactions list that supports date ranges, amount ranges, account(s), category(ies), and free-text search as requested in the issue.  
- Ensure filtered views are bookmarkable/shareable via the URL while keeping existing backend query compatibility.

### Description

- Reworked `TransactionsPage.tsx` to initialize filter state from URL query params and persist changes back to the URL using `history.replaceState`.  
- Added multi-select support for accounts and categories, plus `minAmount`/`maxAmount` inputs and a free-text `q` parameter for note search.  
- Kept server-side query compatibility by only including `accountId`/`categoryId` in the outgoing `apiClient.getTransactions` `filterQuery` when exactly one value is selected, and applied remaining filtering (multi-select, amount range, text search) client-side.  
- Updated `TransactionsPage.test.tsx` to select multi-option filters, assert amount inputs, and verify URL query persistence.

### Testing

- Updated unit tests in `frontend/src/pages/TransactionsPage.test.tsx` to cover multi-select account/category usage, amount range inputs, and URL query assertions.  
- Attempted to run `cd frontend && npm test -- TransactionsPage.test.tsx`, but the local test runner `vitest` is not available in this environment so the automated test run failed (`sh: 1: vitest: not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcab49aadc832480e86949d008c84a)