### PR TITLE
Add bulk transaction actions with filtered select-all

### DIFF
--- a/frontend/src/pages/TransactionsPage.test.tsx
+++ b/frontend/src/pages/TransactionsPage.test.tsx
@@ -298,4 +298,57 @@ describe("TransactionsPage", () => {
     await user.click(screen.getByRole("button", { name: "Move transactions" }));
     await waitFor(() => expect(mocks.createTransaction).toHaveBeenCalledWith("token", expect.objectContaining({ accountId: "account-2" })));
   });
+
+  test("deduplicates transfer group deletes in bulk actions", async () => {
+    const user = userEvent.setup();
+    mocks.getTransactions.mockResolvedValue([
+      {
+        id: "transfer-out",
+        accountId: "account-1",
+        categoryId: null,
+        amount: 100,
+        type: "TransferOut",
+        occurredOnUtc: "2026-04-15T12:00:00Z",
+        note: "Savings move",
+        transferGroupId: "transfer-group-1"
+      },
+      {
+        id: "transfer-in",
+        accountId: "account-2",
+        categoryId: null,
+        amount: 100,
+        type: "TransferIn",
+        occurredOnUtc: "2026-04-15T12:00:00Z",
+        note: "Savings move",
+        transferGroupId: "transfer-group-1"
+      }
+    ]);
+
+    render(<TransactionsPage />);
+
+    await user.click(await screen.findByLabelText("Select all in current filtered view"));
+    await user.click(screen.getByRole("button", { name: "Bulk delete" }));
+
+    await waitFor(() => expect(mocks.deleteTransaction).toHaveBeenCalledTimes(1));
+    expect(mocks.deleteTransaction).toHaveBeenCalledWith("token", "transfer-out");
+  });
+
+  test("limits bulk category assignment to one transaction kind", async () => {
+    const user = userEvent.setup();
+    render(<TransactionsPage />);
+
+    await user.click(await screen.findByLabelText("Select all in current filtered view"));
+
+    expect(screen.getByRole("button", { name: "Apply category" })).toBeDisabled();
+    expect(screen.getByLabelText("Bulk category")).toBeDisabled();
+
+    await user.click(screen.getByLabelText("Select Market"));
+    await user.selectOptions(screen.getByLabelText("Bulk category"), "category-2");
+    await user.click(screen.getByRole("button", { name: "Apply category" }));
+
+    await waitFor(() => {
+      expect(mocks.updateTransaction).toHaveBeenCalledWith("token", "transaction-2", expect.objectContaining({ categoryId: "category-2" }));
+    });
+    expect(mocks.updateTransaction).not.toHaveBeenCalledWith("token", "transaction-1", expect.anything());
+  });
 });

--- a/frontend/src/pages/TransactionsPage.test.tsx
+++ b/frontend/src/pages/TransactionsPage.test.tsx
@@ -279,4 +279,23 @@ describe("TransactionsPage", () => {
     expect(screen.queryByLabelText("New category name")).not.toBeInTheDocument();
     expect(screen.getByLabelText("Destination account")).toBeInTheDocument();
   });
+
+  test("supports select-all bulk delete, category assignment, and account move", async () => {
+    const user = userEvent.setup();
+    render(<TransactionsPage />);
+
+    await user.click(await screen.findByLabelText("Select all in current filtered view"));
+    await user.click(screen.getByRole("button", { name: "Bulk delete" }));
+    await waitFor(() => expect(mocks.deleteTransaction).toHaveBeenCalledTimes(2));
+
+    await user.click(screen.getByLabelText("Select Market"));
+    await user.selectOptions(screen.getByLabelText("Bulk category"), "category-3");
+    await user.click(screen.getByRole("button", { name: "Apply category" }));
+    await waitFor(() => expect(mocks.updateTransaction).toHaveBeenCalledWith("token", "transaction-1", expect.objectContaining({ categoryId: "category-3" })));
+
+    await user.click(screen.getByLabelText("Select Market"));
+    await user.selectOptions(screen.getByLabelText("Move to account"), "account-2");
+    await user.click(screen.getByRole("button", { name: "Move transactions" }));
+    await waitFor(() => expect(mocks.createTransaction).toHaveBeenCalledWith("token", expect.objectContaining({ accountId: "account-2" })));
+  });
 });

--- a/frontend/src/pages/TransactionsPage.tsx
+++ b/frontend/src/pages/TransactionsPage.tsx
@@ -48,6 +48,10 @@ export function TransactionsPage() {
   const [ledgerTransactions, setLedgerTransactions] = useState<Transaction[]>(transactions);
   const [statusMessage, setStatusMessage] = useState("");
   const [errorMessage, setErrorMessage] = useState("");
+  const [selectedTransactionIds, setSelectedTransactionIds] = useState<string[]>([]);
+  const [bulkCategoryId, setBulkCategoryId] = useState("");
+  const [bulkAccountId, setBulkAccountId] = useState("");
+  const [isApplyingBulkAction, setIsApplyingBulkAction] = useState(false);
 
   useEffect(() => {
     setLedgerTransactions(transactions);
@@ -142,6 +146,15 @@ export function TransactionsPage() {
       return (transaction.note ?? "").toLowerCase().includes(normalizedSearch);
     });
   }, [filterType, filterAccountIds, filterCategoryIds, ledgerTransactions, minAmount, maxAmount, noteSearch, showUncategorizedOnly]);
+  useEffect(() => {
+    setSelectedTransactionIds((current) => current.filter((id) => visibleTransactions.some((transaction) => transaction.id === id)));
+  }, [visibleTransactions]);
+
+  const selectedTransactions = useMemo(
+    () => visibleTransactions.filter((transaction) => selectedTransactionIds.includes(transaction.id)),
+    [visibleTransactions, selectedTransactionIds]
+  );
+  const allVisibleSelected = visibleTransactions.length > 0 && selectedTransactionIds.length === visibleTransactions.length;
 
   const expenseCategories = useMemo(
     () => categories.filter((category) => category.kind === "Expense"),
@@ -161,6 +174,19 @@ export function TransactionsPage() {
   const refreshAfterMutation = async () => {
     await refresh();
     await loadTransactions();
+  };
+  const clearSelection = () => {
+    setSelectedTransactionIds([]);
+    setBulkCategoryId("");
+    setBulkAccountId("");
+  };
+  const toggleTransactionSelection = (transactionId: string, selected: boolean) => {
+    setSelectedTransactionIds((current) =>
+      selected ? (current.includes(transactionId) ? current : [...current, transactionId]) : current.filter((id) => id !== transactionId)
+    );
+  };
+  const toggleSelectAllVisible = (selected: boolean) => {
+    setSelectedTransactionIds(selected ? visibleTransactions.map((transaction) => transaction.id) : []);
   };
 
   const startEdit = (transaction: Transaction) => {
@@ -254,6 +280,73 @@ export function TransactionsPage() {
       await refreshAfterMutation();
     } catch (caughtError) {
       setErrorMessage(caughtError instanceof Error ? caughtError.message : t("transactions.unableToCategorize"));
+    }
+  };
+
+  const bulkDeleteTransactions = async () => {
+    if (!auth?.accessToken || selectedTransactions.length === 0) return;
+    try {
+      setIsApplyingBulkAction(true);
+      await Promise.all(selectedTransactions.map((transaction) => apiClient.deleteTransaction(auth.accessToken, transaction.id)));
+      setStatusMessage(`Deleted ${selectedTransactions.length} transactions.`);
+      clearSelection();
+      await refreshAfterMutation();
+    } catch (caughtError) {
+      setErrorMessage(caughtError instanceof Error ? caughtError.message : t("transactions.unableToDelete"));
+    } finally {
+      setIsApplyingBulkAction(false);
+    }
+  };
+  const bulkAssignCategory = async () => {
+    if (!auth?.accessToken || !bulkCategoryId || selectedTransactions.length === 0) return;
+    const targets = selectedTransactions.filter((transaction) => transaction.type !== "Transfer");
+    try {
+      setIsApplyingBulkAction(true);
+      await Promise.all(
+        targets.map((transaction) =>
+          apiClient.updateTransaction(auth.accessToken, transaction.id, {
+            categoryId: bulkCategoryId,
+            amount: transaction.amount,
+            type: transaction.type,
+            occurredOnUtc: transaction.occurredOnUtc,
+            note: transaction.note?.trim() || undefined
+          })
+        )
+      );
+      setStatusMessage(`Updated category for ${targets.length} transactions.`);
+      clearSelection();
+      await refreshAfterMutation();
+    } catch (caughtError) {
+      setErrorMessage(caughtError instanceof Error ? caughtError.message : t("transactions.unableToCategorize"));
+    } finally {
+      setIsApplyingBulkAction(false);
+    }
+  };
+  const bulkMoveAccount = async () => {
+    if (!auth?.accessToken || !bulkAccountId || selectedTransactions.length === 0) return;
+    const targets = selectedTransactions.filter((transaction) => !transaction.type.startsWith("Transfer"));
+    try {
+      setIsApplyingBulkAction(true);
+      await Promise.all(
+        targets.map(async (transaction) => {
+          await apiClient.createTransaction(auth.accessToken, {
+            accountId: bulkAccountId,
+            categoryId: transaction.categoryId ?? undefined,
+            amount: transaction.amount,
+            type: transaction.type,
+            occurredOnUtc: transaction.occurredOnUtc,
+            note: transaction.note ?? undefined
+          });
+          await apiClient.deleteTransaction(auth.accessToken!, transaction.id);
+        })
+      );
+      setStatusMessage(`Moved ${targets.length} transactions to the selected account.`);
+      clearSelection();
+      await refreshAfterMutation();
+    } catch (caughtError) {
+      setErrorMessage(caughtError instanceof Error ? caughtError.message : "Unable to move selected transactions.");
+    } finally {
+      setIsApplyingBulkAction(false);
     }
   };
 
@@ -362,6 +455,36 @@ export function TransactionsPage() {
               {t("transactions.workflowBanner", { count: uncategorizedExpenseCount })}
             </p>
           ) : null}
+          {visibleTransactions.length > 0 ? (
+            <div className="review-toolbar" aria-label="Bulk transaction actions">
+              <div className="review-toolbar-actions">
+                <label className="inline-checkbox">
+                  <input type="checkbox" checked={allVisibleSelected} onChange={(event) => toggleSelectAllVisible(event.target.checked)} />
+                  Select all in current filtered view
+                </label>
+                <strong>{selectedTransactionIds.length} selected</strong>
+              </div>
+              <div className="bulk-category-actions">
+                <button className="ghost-button compact-button danger-button" type="button" onClick={() => void bulkDeleteTransactions()} disabled={selectedTransactionIds.length === 0 || isApplyingBulkAction}>Bulk delete</button>
+                <label>
+                  Bulk category
+                  <select value={bulkCategoryId} onChange={(event) => setBulkCategoryId(event.target.value)}>
+                    <option value="">{t("common.chooseCategory")}</option>
+                    {expenseCategories.map((category) => <option key={category.id} value={category.id}>{category.name}</option>)}
+                  </select>
+                </label>
+                <button className="ghost-button compact-button" type="button" onClick={() => void bulkAssignCategory()} disabled={selectedTransactionIds.length === 0 || !bulkCategoryId || isApplyingBulkAction}>Apply category</button>
+                <label>
+                  Move to account
+                  <select value={bulkAccountId} onChange={(event) => setBulkAccountId(event.target.value)}>
+                    <option value="">{t("common.selectAccount")}</option>
+                    {accounts.map((account) => <option key={account.id} value={account.id}>{account.name}</option>)}
+                  </select>
+                </label>
+                <button className="ghost-button compact-button" type="button" onClick={() => void bulkMoveAccount()} disabled={selectedTransactionIds.length === 0 || !bulkAccountId || isApplyingBulkAction}>Move transactions</button>
+              </div>
+            </div>
+          ) : null}
 
           <div className="table-list transaction-list">
             {visibleTransactions.length === 0 ? (
@@ -374,6 +497,9 @@ export function TransactionsPage() {
 
                 return (
                   <article className="table-row transaction-row" key={transaction.id} aria-label={t("transactions.rowLabel", { label })}>
+                    <label className="inline-checkbox">
+                      <input type="checkbox" checked={selectedTransactionIds.includes(transaction.id)} onChange={(event) => toggleTransactionSelection(transaction.id, event.target.checked)} aria-label={`Select ${label}`} />
+                    </label>
                     <div className="transaction-main">
                       <strong>{category?.name ?? getTransactionTypeLabel(toFormType(transaction.type), t)}</strong>
                       <p>{account?.name ?? t("transactions.unknownAccount")} • {formatDate(transaction.occurredOnUtc)}</p>

--- a/frontend/src/pages/TransactionsPage.tsx
+++ b/frontend/src/pages/TransactionsPage.tsx
@@ -28,6 +28,14 @@ function transactionLabel(transaction: Transaction, t: ReturnType<typeof useI18n
   return transaction.note?.trim() || categoryName || getTransactionTypeLabel(transaction.type, t);
 }
 
+function isTransferTransaction(transaction: Transaction) {
+  return transaction.type.startsWith("Transfer");
+}
+
+function getCategorisableTransactionKind(transaction: Transaction) {
+  return transaction.type === "Expense" || transaction.type === "Income" ? transaction.type : "";
+}
+
 export function TransactionsPage() {
   const { auth } = useAuth();
   const { t } = useI18n();
@@ -155,7 +163,24 @@ export function TransactionsPage() {
     [visibleTransactions, selectedTransactionIds]
   );
   const allVisibleSelected = visibleTransactions.length > 0 && selectedTransactionIds.length === visibleTransactions.length;
+  const selectedCategorisableTransactions = useMemo(
+    () => selectedTransactions.filter((transaction) => getCategorisableTransactionKind(transaction)),
+    [selectedTransactions]
+  );
+  const bulkCategoryKind = useMemo(() => {
+    const selectedKinds = new Set(selectedCategorisableTransactions.map(getCategorisableTransactionKind));
+    return selectedKinds.size === 1 ? Array.from(selectedKinds)[0] : "";
+  }, [selectedCategorisableTransactions]);
 
+  const bulkCategories = useMemo(
+    () => categories.filter((category) => bulkCategoryKind && category.kind === bulkCategoryKind),
+    [bulkCategoryKind, categories]
+  );
+  useEffect(() => {
+    if (bulkCategoryId && !bulkCategories.some((category) => category.id === bulkCategoryId)) {
+      setBulkCategoryId("");
+    }
+  }, [bulkCategories, bulkCategoryId]);
   const expenseCategories = useMemo(
     () => categories.filter((category) => category.kind === "Expense"),
     [categories]
@@ -188,6 +213,17 @@ export function TransactionsPage() {
   const toggleSelectAllVisible = (selected: boolean) => {
     setSelectedTransactionIds(selected ? visibleTransactions.map((transaction) => transaction.id) : []);
   };
+  const getUniqueDeleteTargets = () => {
+    const deleteTargets = new Map<string, Transaction>();
+    selectedTransactions.forEach((transaction) => {
+      const deleteKey = transaction.transferGroupId ? `transfer:${transaction.transferGroupId}` : `transaction:${transaction.id}`;
+      if (!deleteTargets.has(deleteKey)) {
+        deleteTargets.set(deleteKey, transaction);
+      }
+    });
+
+    return Array.from(deleteTargets.values());
+  };
 
   const startEdit = (transaction: Transaction) => {
     setFormMode("edit");
@@ -210,7 +246,7 @@ export function TransactionsPage() {
       return;
     }
 
-    if (transaction.type.startsWith("Transfer")) {
+    if (isTransferTransaction(transaction)) {
       setFormMode("create");
       setFormValues({
         type: "Transfer",
@@ -285,9 +321,10 @@ export function TransactionsPage() {
 
   const bulkDeleteTransactions = async () => {
     if (!auth?.accessToken || selectedTransactions.length === 0) return;
+    const deleteTargets = getUniqueDeleteTargets();
     try {
       setIsApplyingBulkAction(true);
-      await Promise.all(selectedTransactions.map((transaction) => apiClient.deleteTransaction(auth.accessToken, transaction.id)));
+      await Promise.all(deleteTargets.map((transaction) => apiClient.deleteTransaction(auth.accessToken, transaction.id)));
       setStatusMessage(`Deleted ${selectedTransactions.length} transactions.`);
       clearSelection();
       await refreshAfterMutation();
@@ -298,12 +335,11 @@ export function TransactionsPage() {
     }
   };
   const bulkAssignCategory = async () => {
-    if (!auth?.accessToken || !bulkCategoryId || selectedTransactions.length === 0) return;
-    const targets = selectedTransactions.filter((transaction) => transaction.type !== "Transfer");
+    if (!auth?.accessToken || !bulkCategoryId || selectedCategorisableTransactions.length === 0 || !bulkCategoryKind) return;
     try {
       setIsApplyingBulkAction(true);
       await Promise.all(
-        targets.map((transaction) =>
+        selectedCategorisableTransactions.map((transaction) =>
           apiClient.updateTransaction(auth.accessToken, transaction.id, {
             categoryId: bulkCategoryId,
             amount: transaction.amount,
@@ -313,7 +349,7 @@ export function TransactionsPage() {
           })
         )
       );
-      setStatusMessage(`Updated category for ${targets.length} transactions.`);
+      setStatusMessage(`Updated category for ${selectedCategorisableTransactions.length} transactions.`);
       clearSelection();
       await refreshAfterMutation();
     } catch (caughtError) {
@@ -324,7 +360,7 @@ export function TransactionsPage() {
   };
   const bulkMoveAccount = async () => {
     if (!auth?.accessToken || !bulkAccountId || selectedTransactions.length === 0) return;
-    const targets = selectedTransactions.filter((transaction) => !transaction.type.startsWith("Transfer"));
+    const targets = selectedTransactions.filter((transaction) => !isTransferTransaction(transaction));
     try {
       setIsApplyingBulkAction(true);
       await Promise.all(
@@ -468,12 +504,12 @@ export function TransactionsPage() {
                 <button className="ghost-button compact-button danger-button" type="button" onClick={() => void bulkDeleteTransactions()} disabled={selectedTransactionIds.length === 0 || isApplyingBulkAction}>Bulk delete</button>
                 <label>
                   Bulk category
-                  <select value={bulkCategoryId} onChange={(event) => setBulkCategoryId(event.target.value)}>
+                  <select value={bulkCategoryId} onChange={(event) => setBulkCategoryId(event.target.value)} disabled={!bulkCategoryKind}>
                     <option value="">{t("common.chooseCategory")}</option>
-                    {expenseCategories.map((category) => <option key={category.id} value={category.id}>{category.name}</option>)}
+                    {bulkCategories.map((category) => <option key={category.id} value={category.id}>{category.name}</option>)}
                   </select>
                 </label>
-                <button className="ghost-button compact-button" type="button" onClick={() => void bulkAssignCategory()} disabled={selectedTransactionIds.length === 0 || !bulkCategoryId || isApplyingBulkAction}>Apply category</button>
+                <button className="ghost-button compact-button" type="button" onClick={() => void bulkAssignCategory()} disabled={selectedCategorisableTransactions.length === 0 || !bulkCategoryKind || !bulkCategoryId || isApplyingBulkAction}>Apply category</button>
                 <label>
                   Move to account
                   <select value={bulkAccountId} onChange={(event) => setBulkAccountId(event.target.value)}>


### PR DESCRIPTION
### Motivation
- Provide users the ability to act on multiple transactions at once from the Transactions ledger view (bulk delete, bulk category assignment, bulk account move) to speed up review and cleanup workflows. 
- Support selecting the current filtered view with a single control so bulk actions apply only to what the user sees.

### Description
- Added per-row selection checkboxes and a context toolbar to `frontend/src/pages/TransactionsPage.tsx` that shows a `Select all in current filtered view` checkbox, selected count, and bulk action controls. 
- Implemented bulk actions using existing API calls: `Bulk delete` (parallel `deleteTransaction` calls), `Bulk category` (parallel `updateTransaction` for non-transfer rows), and `Move to account` (create transaction on target account then delete original for non-transfer rows). 
- Added selection state management (`selectedTransactionIds`, `bulkCategoryId`, `bulkAccountId`, `isApplyingBulkAction`) and helpers to keep selection in sync with the current filtered results and to clear selection after successful operations. 
- Added a test exercising the select-all and bulk action flows in `frontend/src/pages/TransactionsPage.test.tsx`.

### Testing
- Added unit test `supports select-all bulk delete, category assignment, and account move` in `TransactionsPage.test.tsx` which simulates select-all, per-row select, apply category, and move account actions and asserts API calls. 
- Attempted to run tests with `cd frontend && npm test -- TransactionsPage.test.tsx`, but the environment reported `vitest: not found` so tests could not be executed locally. 
- Attempted `cd frontend && npx vitest run src/pages/TransactionsPage.test.tsx`, but dependency installation failed due to npm registry access (`403 Forbidden`), so automated test execution did not complete in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fcb112507083249735ee43efe40384)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Bulk transaction operations: select multiple transactions to delete, reassign categories, or move accounts simultaneously.
  * Added selection checkboxes to each transaction row and a toolbar with bulk action controls.
  * Selection automatically clears when transaction filters change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->