### PR TITLE
Add ability to move transactions between accounts

### DIFF
--- a/backend/src/Ledgerra.Api/Contracts/TransactionContracts.cs
+++ b/backend/src/Ledgerra.Api/Contracts/TransactionContracts.cs
@@ -51,6 +51,12 @@ public sealed class UpdateTransactionRequest
     public IReadOnlyList<TransactionSplitLineRequest>? SplitLines { get; init; }
 }
 
+public sealed class MoveTransactionAccountRequest
+{
+    [Required]
+    public Guid DestinationAccountId { get; init; }
+}
+
 public sealed class TransactionSplitLineRequest
 {
     [Required]

--- a/backend/src/Ledgerra.Api/Controllers/TransactionsController.cs
+++ b/backend/src/Ledgerra.Api/Controllers/TransactionsController.cs
@@ -16,19 +16,22 @@ public sealed class TransactionsController : ControllerBase
     private readonly GetTransactionsQueryHandler _getTransactionsQueryHandler;
     private readonly UpdateTransactionCommandHandler _updateTransactionCommandHandler;
     private readonly DeleteTransactionCommandHandler _deleteTransactionCommandHandler;
+    private readonly MoveTransactionAccountCommandHandler _moveTransactionAccountCommandHandler;
 
     public TransactionsController(
         CreateTransactionCommandHandler createTransactionCommandHandler,
         GetTransactionByIdQueryHandler getTransactionByIdQueryHandler,
         GetTransactionsQueryHandler getTransactionsQueryHandler,
         UpdateTransactionCommandHandler updateTransactionCommandHandler,
-        DeleteTransactionCommandHandler deleteTransactionCommandHandler)
+        DeleteTransactionCommandHandler deleteTransactionCommandHandler,
+        MoveTransactionAccountCommandHandler moveTransactionAccountCommandHandler)
     {
         _createTransactionCommandHandler = createTransactionCommandHandler;
         _getTransactionByIdQueryHandler = getTransactionByIdQueryHandler;
         _getTransactionsQueryHandler = getTransactionsQueryHandler;
         _updateTransactionCommandHandler = updateTransactionCommandHandler;
         _deleteTransactionCommandHandler = deleteTransactionCommandHandler;
+        _moveTransactionAccountCommandHandler = moveTransactionAccountCommandHandler;
     }
 
     [HttpGet]
@@ -108,6 +111,35 @@ public sealed class TransactionsController : ControllerBase
                 request.Note,
                 request.SavingsGoalId,
                 request.SplitLines?.Select(line => new TransactionSplitLine(line.CategoryId, line.Amount)).ToList()),
+            cancellationToken);
+
+        if (result.IsNotFound)
+        {
+            return NotFound(new ProblemDetails
+            {
+                Title = result.NotFoundTitle
+            });
+        }
+
+        if (result.HasValidationError)
+        {
+            return this.ValidationError(new Dictionary<string, string[]>
+            {
+                [result.ValidationKey!] = [result.ValidationMessage!]
+            });
+        }
+
+        return Ok(MapTransaction(result.Transaction!));
+    }
+
+    [HttpPost("{id:guid}/move-account")]
+    public async Task<ActionResult<TransactionResponse>> MoveAccount(
+        Guid id,
+        MoveTransactionAccountRequest request,
+        CancellationToken cancellationToken)
+    {
+        var result = await _moveTransactionAccountCommandHandler.HandleAsync(
+            new MoveTransactionAccountCommand(User.GetRequiredUserId(), id, request.DestinationAccountId),
             cancellationToken);
 
         if (result.IsNotFound)

--- a/backend/src/Ledgerra.Api/Program.cs
+++ b/backend/src/Ledgerra.Api/Program.cs
@@ -52,6 +52,7 @@ builder.Services.AddScoped<IMonthlyReportAnalyzer, MonthlyReportAnalysisAdapter>
 builder.Services.AddScoped<IMonthlyReportDuplicateMarker, MonthlyReportDuplicateMarkerAdapter>();
 builder.Services.AddScoped<CreateTransactionCommandHandler>();
 builder.Services.AddScoped<DeleteTransactionCommandHandler>();
+builder.Services.AddScoped<MoveTransactionAccountCommandHandler>();
 builder.Services.AddScoped<GetProfileQueryHandler>();
 builder.Services.AddScoped<IMonthlyReportDuplicateReviewer, MonthlyReportDuplicateReviewerAdapter>();
 builder.Services.AddScoped<IMonthlyReportImportCommitStore, MonthlyReportImportCommitStore>();

--- a/backend/src/Ledgerra.Application/Transactions/TransactionCommandUseCases.cs
+++ b/backend/src/Ledgerra.Application/Transactions/TransactionCommandUseCases.cs
@@ -31,6 +31,8 @@ public sealed record TransactionSplitLine(Guid CategoryId, decimal Amount);
 
 public sealed record DeleteTransactionCommand(Guid UserId, Guid TransactionId);
 
+public sealed record MoveTransactionAccountCommand(Guid UserId, Guid TransactionId, Guid DestinationAccountId);
+
 public sealed record TransactionDetails(
     Guid Id,
     Guid AccountId,
@@ -55,6 +57,11 @@ public interface ITransactionCommandStore
     Task DeleteAsync(Transaction transaction, CancellationToken cancellationToken);
 
     Task DeleteTransferGroupAsync(Guid userId, Guid transferGroupId, CancellationToken cancellationToken);
+
+    Task<Transaction> MoveToAccountAsync(
+        Transaction existing,
+        Guid destinationAccountId,
+        CancellationToken cancellationToken);
 
     Task<Transaction> CreateAsync(
         Transaction transaction,
@@ -414,6 +421,57 @@ public sealed class DeleteTransactionCommandHandler
         }
 
         return TransactionDeleteResult.Success();
+    }
+}
+
+public sealed class MoveTransactionAccountCommandHandler
+{
+    private readonly ITransactionCommandStore _transactionCommandStore;
+    private readonly IMonthlyAccountBalanceSnapshotService? _snapshotService;
+
+    public MoveTransactionAccountCommandHandler(
+        ITransactionCommandStore transactionCommandStore,
+        IMonthlyAccountBalanceSnapshotService? snapshotService = null)
+    {
+        _transactionCommandStore = transactionCommandStore;
+        _snapshotService = snapshotService;
+    }
+
+    public async Task<TransactionCommandResult> HandleAsync(MoveTransactionAccountCommand command, CancellationToken cancellationToken)
+    {
+        var existing = await _transactionCommandStore.GetByIdAsync(command.UserId, command.TransactionId, cancellationToken);
+        if (existing is null)
+        {
+            return TransactionCommandResult.NotFound();
+        }
+
+        if (existing.TransferGroupId.HasValue)
+        {
+            return TransactionCommandResult.ValidationError("transactionId", "Transfer transactions cannot be moved to another account.");
+        }
+
+        if (existing.AccountId == command.DestinationAccountId)
+        {
+            return TransactionCommandResult.ValidationError("destinationAccountId", "Destination account must be different from the current account.");
+        }
+
+        var destinationExists = await _transactionCommandStore.AccountExistsAsync(command.UserId, command.DestinationAccountId, cancellationToken);
+        if (!destinationExists)
+        {
+            return TransactionCommandResult.NotFound("Destination account not found");
+        }
+
+        var previousAccountId = existing.AccountId;
+        var transaction = await _transactionCommandStore.MoveToAccountAsync(existing, command.DestinationAccountId, cancellationToken);
+
+        if (_snapshotService is not null)
+        {
+            var refreshFrom = new DateOnly(existing.OccurredOnUtc.Year, existing.OccurredOnUtc.Month, 1);
+            await _snapshotService.RefreshFromAsync(command.UserId, refreshFrom, previousAccountId, cancellationToken);
+            await _snapshotService.RefreshFromAsync(command.UserId, refreshFrom, command.DestinationAccountId, cancellationToken);
+        }
+
+        return TransactionCommandResult.Success(CreateTransactionCommandHandler.MapTransaction(transaction));
     }
 }
 

--- a/backend/src/Ledgerra.Infrastructure/Persistence/TransactionCommandStore.cs
+++ b/backend/src/Ledgerra.Infrastructure/Persistence/TransactionCommandStore.cs
@@ -56,6 +56,31 @@ public sealed class TransactionCommandStore : ITransactionCommandStore
         await _dbContext.SaveChangesAsync(cancellationToken);
     }
 
+    public async Task<Transaction> MoveToAccountAsync(
+        Transaction existing,
+        Guid destinationAccountId,
+        CancellationToken cancellationToken)
+    {
+        if (existing.SplitGroupId.HasValue)
+        {
+            var linkedTransactions = await _dbContext.Transactions
+                .Where(item => item.UserId == existing.UserId && item.SplitGroupId == existing.SplitGroupId.Value)
+                .ToListAsync(cancellationToken);
+
+            foreach (var transaction in linkedTransactions)
+            {
+                transaction.AccountId = destinationAccountId;
+            }
+        }
+        else
+        {
+            existing.AccountId = destinationAccountId;
+        }
+
+        await _dbContext.SaveChangesAsync(cancellationToken);
+        return existing;
+    }
+
     public async Task<Transaction> CreateAsync(
         Transaction transaction,
         CancellationToken cancellationToken,

--- a/backend/tests/Ledgerra.Api.Tests/ApiWorkflowTests.cs
+++ b/backend/tests/Ledgerra.Api.Tests/ApiWorkflowTests.cs
@@ -244,6 +244,91 @@ public sealed class ApiWorkflowTests : IClassFixture<LedgerraApiFactory>
     }
 
     [Fact]
+    public async Task AuthenticatedUser_CanMoveNonTransferTransactionToAnotherAccount()
+    {
+        using var client = _factory.CreateClient();
+
+        var auth = await RegisterAndAuthenticateAsync(client);
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", auth.AccessToken);
+
+        var checkingId = await CreateAccountAsync(client, "Personal Checking", "Checking", 1500m);
+        var savingsId = await CreateAccountAsync(client, "Savings", "Savings", 600m);
+        var groceriesCategoryId = await CreateCategoryAsync(client, "Groceries", "Expense");
+
+        var createResponse = await client.PostAsJsonAsync("/api/transactions", new
+        {
+            accountId = checkingId,
+            categoryId = groceriesCategoryId,
+            amount = 42.17m,
+            type = "Expense",
+            occurredOnUtc = "2026-04-10T08:00:00Z",
+            note = "Weekly groceries"
+        });
+
+        Assert.Equal(HttpStatusCode.Created, createResponse.StatusCode);
+        var createdPayload = await createResponse.Content.ReadFromJsonAsync<JsonElement>();
+        var transactionId = createdPayload.GetProperty("id").GetGuid();
+
+        var moveResponse = await client.PostAsJsonAsync($"/api/transactions/{transactionId}/move-account", new
+        {
+            destinationAccountId = savingsId
+        });
+
+        Assert.Equal(HttpStatusCode.OK, moveResponse.StatusCode);
+        var movedPayload = await moveResponse.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal(transactionId, movedPayload.GetProperty("id").GetGuid());
+        Assert.Equal(savingsId, movedPayload.GetProperty("accountId").GetGuid());
+
+        var checkingTransactionsResponse = await client.GetAsync($"/api/transactions?accountId={checkingId}");
+        var checkingTransactions = await checkingTransactionsResponse.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal(0, checkingTransactions.GetArrayLength());
+
+        var savingsTransactionsResponse = await client.GetAsync($"/api/transactions?accountId={savingsId}");
+        var savingsTransactions = await savingsTransactionsResponse.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Single(savingsTransactions.EnumerateArray());
+        Assert.Equal(transactionId, savingsTransactions[0].GetProperty("id").GetGuid());
+    }
+
+    [Fact]
+    public async Task AuthenticatedUser_CannotMoveTransferTransactionToAnotherAccount()
+    {
+        using var client = _factory.CreateClient();
+
+        var auth = await RegisterAndAuthenticateAsync(client);
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", auth.AccessToken);
+
+        var checkingId = await CreateAccountAsync(client, "Personal Checking", "Checking", 1500m);
+        var savingsId = await CreateAccountAsync(client, "Savings", "Savings", 600m);
+        var jointId = await CreateAccountAsync(client, "Shared Household", "Joint", 600m);
+
+        var createResponse = await client.PostAsJsonAsync("/api/transactions", new
+        {
+            accountId = checkingId,
+            destinationAccountId = savingsId,
+            amount = 200m,
+            type = "Transfer",
+            occurredOnUtc = "2026-04-06T08:00:00Z",
+            note = "Move to savings"
+        });
+
+        Assert.Equal(HttpStatusCode.Created, createResponse.StatusCode);
+        var createdPayload = await createResponse.Content.ReadFromJsonAsync<JsonElement>();
+        var transactionId = createdPayload.GetProperty("id").GetGuid();
+
+        var moveResponse = await client.PostAsJsonAsync($"/api/transactions/{transactionId}/move-account", new
+        {
+            destinationAccountId = jointId
+        });
+
+        Assert.Equal(HttpStatusCode.BadRequest, moveResponse.StatusCode);
+
+        var checkingTransactionsResponse = await client.GetAsync($"/api/transactions?accountId={checkingId}");
+        var checkingTransactions = await checkingTransactionsResponse.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Single(checkingTransactions.EnumerateArray());
+        Assert.Equal(transactionId, checkingTransactions[0].GetProperty("id").GetGuid());
+    }
+
+    [Fact]
     public async Task AuthenticatedUser_CanFilterTransactionsAndGetTransactionById()
     {
         using var client = _factory.CreateClient();

--- a/backend/tests/Ledgerra.Api.Tests/ApplicationReviewRegressionTests.cs
+++ b/backend/tests/Ledgerra.Api.Tests/ApplicationReviewRegressionTests.cs
@@ -263,6 +263,15 @@ public sealed class ApplicationReviewRegressionTests
             return Task.FromResult(transaction);
         }
 
+        public Task<Transaction> MoveToAccountAsync(
+            Transaction existing,
+            Guid destinationAccountId,
+            CancellationToken cancellationToken)
+        {
+            existing.AccountId = destinationAccountId;
+            return Task.FromResult(existing);
+        }
+
         public Task<Transaction> CreateTransferAsync(
             Guid userId,
             Guid sourceAccountId,

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -24,6 +24,14 @@ type RequestOptions = {
   token?: string | null;
 };
 
+type UnauthorizedListener = () => void;
+
+const unauthorizedListeners = new Set<UnauthorizedListener>();
+
+function notifyUnauthorized() {
+  unauthorizedListeners.forEach((listener) => listener());
+}
+
 async function request<T>(path: string, options: RequestOptions = {}): Promise<T> {
   const response = await fetch(`${API_BASE_URL}${path}`, {
     method: options.method ?? "GET",
@@ -35,6 +43,10 @@ async function request<T>(path: string, options: RequestOptions = {}): Promise<T
   });
 
   if (!response.ok) {
+    if (response.status === 401) {
+      notifyUnauthorized();
+    }
+
     throw new Error(await readErrorMessage(response));
   }
 
@@ -70,6 +82,12 @@ async function readErrorMessage(response: Response): Promise<string> {
 }
 
 export const apiClient = {
+  onUnauthorized(listener: UnauthorizedListener) {
+    unauthorizedListeners.add(listener);
+    return () => {
+      unauthorizedListeners.delete(listener);
+    };
+  },
   register(email: string, password: string) {
     return request<AuthPayload>("/api/auth/register", {
       method: "POST",
@@ -244,6 +262,13 @@ export const apiClient = {
       token
     });
   },
+  moveTransactionAccount(token: string, transactionId: string, destinationAccountId: string) {
+    return request<Transaction>(`/api/transactions/${transactionId}/move-account`, {
+      method: "POST",
+      token,
+      body: { destinationAccountId }
+    });
+  },
   analyzeMonthlyReport(token: string, payload: { accountId: string; month: string; provider: string; file: File }) {
     const body = new FormData();
     body.append("accountId", payload.accountId);
@@ -257,6 +282,10 @@ export const apiClient = {
       body
     }).then(async (response) => {
       if (!response.ok) {
+        if (response.status === 401) {
+          notifyUnauthorized();
+        }
+
         throw new Error(await readErrorMessage(response));
       }
 

--- a/frontend/src/hooks/useLedgerraData.ts
+++ b/frontend/src/hooks/useLedgerraData.ts
@@ -5,10 +5,30 @@ import { useI18n } from "../state/I18nContext";
 import { useMonthSelection } from "../state/MonthContext";
 import type { Account, AiSettings, BudgetSummary, Category, DashboardSummary, ImportRule, Profile, Transaction } from "../types";
 
-export function useLedgerraData() {
+type LedgerraDataOptions = {
+  profile?: boolean;
+  aiSettings?: boolean;
+  dashboard?: boolean;
+  accounts?: boolean;
+  categories?: boolean;
+  transactions?: boolean;
+  budget?: boolean;
+  importRules?: boolean;
+};
+
+export function useLedgerraData(options: LedgerraDataOptions = {}) {
   const { auth } = useAuth();
   const { setLanguageCode, t } = useI18n();
   const { selectedMonth, selectedYear, selectedMonthNumber } = useMonthSelection();
+  const loadAll = Object.keys(options).length === 0;
+  const loadProfile = options.profile ?? loadAll;
+  const loadAiSettings = options.aiSettings ?? loadAll;
+  const loadDashboard = options.dashboard ?? loadAll;
+  const loadAccounts = options.accounts ?? loadAll;
+  const loadCategories = options.categories ?? loadAll;
+  const loadTransactions = options.transactions ?? loadAll;
+  const loadBudget = options.budget ?? loadAll;
+  const loadImportRules = options.importRules ?? loadAll;
   const translatorRef = useRef(t);
   const [dashboard, setDashboard] = useState<DashboardSummary | null>(null);
   const [profile, setProfile] = useState<Profile | null>(null);
@@ -44,30 +64,43 @@ export function useLedgerraData() {
         budgetPayload,
         importRulesPayload
       ] = await Promise.all([
-        apiClient.getProfile(auth.accessToken),
-        apiClient.getAiSettings(auth.accessToken),
-        apiClient.getDashboard(auth.accessToken, selectedMonth),
-        apiClient.getAccounts(auth.accessToken),
-        apiClient.getCategories(auth.accessToken),
-        apiClient.getTransactions(auth.accessToken),
-        apiClient.getBudget(auth.accessToken, selectedYear, selectedMonthNumber),
-        apiClient.getImportRules(auth.accessToken).catch(() => [])
+        loadProfile ? apiClient.getProfile(auth.accessToken) : Promise.resolve(null),
+        loadAiSettings ? apiClient.getAiSettings(auth.accessToken) : Promise.resolve(null),
+        loadDashboard ? apiClient.getDashboard(auth.accessToken, selectedMonth) : Promise.resolve(null),
+        loadAccounts ? apiClient.getAccounts(auth.accessToken) : Promise.resolve([]),
+        loadCategories ? apiClient.getCategories(auth.accessToken) : Promise.resolve([]),
+        loadTransactions ? apiClient.getTransactions(auth.accessToken) : Promise.resolve([]),
+        loadBudget ? apiClient.getBudget(auth.accessToken, selectedYear, selectedMonthNumber) : Promise.resolve(null),
+        loadImportRules ? apiClient.getImportRules(auth.accessToken).catch(() => []) : Promise.resolve([])
       ]);
 
-      setProfile(profilePayload);
-      setAiSettings(aiSettingsPayload);
-      setDashboard(dashboardPayload);
-      setAccounts(accountsPayload);
-      setCategories(categoriesPayload);
-      setTransactions(transactionsPayload);
-      setBudget(budgetPayload);
-      setImportRules(importRulesPayload);
+      if (loadProfile) setProfile(profilePayload);
+      if (loadAiSettings) setAiSettings(aiSettingsPayload);
+      if (loadDashboard) setDashboard(dashboardPayload);
+      if (loadAccounts) setAccounts(accountsPayload);
+      if (loadCategories) setCategories(categoriesPayload);
+      if (loadTransactions) setTransactions(transactionsPayload);
+      if (loadBudget) setBudget(budgetPayload);
+      if (loadImportRules) setImportRules(importRulesPayload);
     } catch (caughtError) {
       setError(caughtError instanceof Error ? caughtError.message : translatorRef.current("common.unknown"));
     } finally {
       setLoading(false);
     }
-  }, [auth?.accessToken, selectedMonth, selectedMonthNumber, selectedYear]);
+  }, [
+    auth?.accessToken,
+    loadAccounts,
+    loadAiSettings,
+    loadBudget,
+    loadCategories,
+    loadDashboard,
+    loadImportRules,
+    loadProfile,
+    loadTransactions,
+    selectedMonth,
+    selectedMonthNumber,
+    selectedYear
+  ]);
 
   useEffect(() => {
     void refresh();

--- a/frontend/src/pages/AccountsPage.tsx
+++ b/frontend/src/pages/AccountsPage.tsx
@@ -30,7 +30,10 @@ function getAccountTypeLabel(type: string, t: ReturnType<typeof useI18n>["t"]) {
 export function AccountsPage() {
   const { auth } = useAuth();
   const { t } = useI18n();
-  const { accounts, profile, refresh } = useLedgerraData();
+  const { accounts, profile, refresh } = useLedgerraData({
+    accounts: true,
+    profile: true
+  });
   const [name, setName] = useState("");
   const [type, setType] = useState("Checking");
   const [currencyCode, setCurrencyCode] = useState("USD");

--- a/frontend/src/pages/BudgetsPage.tsx
+++ b/frontend/src/pages/BudgetsPage.tsx
@@ -12,7 +12,11 @@ export function BudgetsPage() {
   const { auth } = useAuth();
   const { t } = useI18n();
   const { selectedYear, selectedMonthNumber } = useMonthSelection();
-  const { categories, budget, profile, refresh } = useLedgerraData();
+  const { categories, budget, profile, refresh } = useLedgerraData({
+    categories: true,
+    budget: true,
+    profile: true
+  });
   const mainCurrencyCode = profile?.preferredCurrencyCode ?? "USD";
   const expenseCategories = useMemo(
     () => categories.filter((category) => category.kind === "Expense"),

--- a/frontend/src/pages/CategoriesPage.tsx
+++ b/frontend/src/pages/CategoriesPage.tsx
@@ -20,7 +20,7 @@ function getCategoryKindLabel(kind: string, t: ReturnType<typeof useI18n>["t"]) 
 export function CategoriesPage() {
   const { auth } = useAuth();
   const { t } = useI18n();
-  const { categories, refresh } = useLedgerraData();
+  const { categories, refresh } = useLedgerraData({ categories: true });
   const [name, setName] = useState("");
   const [kind, setKind] = useState("Expense");
   const [color, setColor] = useState("#5f8f7b");

--- a/frontend/src/pages/DashboardPage.tsx
+++ b/frontend/src/pages/DashboardPage.tsx
@@ -206,7 +206,14 @@ function buildDashboardInsights(
 export function DashboardPage() {
   const { auth } = useAuth();
   const { t } = useI18n();
-  const { accounts, categories, dashboard, budget, loading, error, profile, transactions, refresh } = useLedgerraData();
+  const { accounts, categories, dashboard, budget, loading, error, profile, transactions, refresh } = useLedgerraData({
+    accounts: true,
+    categories: true,
+    dashboard: true,
+    budget: true,
+    profile: true,
+    transactions: true
+  });
   const mainCurrencyCode = profile?.preferredCurrencyCode ?? "USD";
   const acknowledgementStorageKey = `ledgerra:onboarding:${profile?.email ?? "anonymous"}`;
   const widgetPreferenceStorageKey = `ledgerra:dashboard-widgets:${profile?.email ?? "anonymous"}`;

--- a/frontend/src/pages/GoalsPage.tsx
+++ b/frontend/src/pages/GoalsPage.tsx
@@ -9,7 +9,7 @@ import { formatCurrency } from "../utils/format";
 
 export function GoalsPage() {
   const { auth } = useAuth();
-  const { profile } = useLedgerraData();
+  const { profile } = useLedgerraData({ profile: true });
   const [goals, setGoals] = useState<SavingsGoal[]>([]);
   const [name, setName] = useState("");
   const [targetAmount, setTargetAmount] = useState("0");

--- a/frontend/src/pages/ImportsPage.tsx
+++ b/frontend/src/pages/ImportsPage.tsx
@@ -21,7 +21,11 @@ function getErrorMessage(exception: unknown, fallback: string) {
 export function ImportsPage() {
   const { auth } = useAuth();
   const { t } = useI18n();
-  const { accounts, categories, aiSettings, refresh } = useLedgerraData();
+  const { accounts, categories, aiSettings, refresh } = useLedgerraData({
+    accounts: true,
+    categories: true,
+    aiSettings: true
+  });
   const [accountId, setAccountId] = useState("");
   const [month, setMonth] = useState(new Date().toISOString().slice(0, 7));
   const [provider, setProvider] = useState("OpenAi");

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -18,7 +18,12 @@ export function SettingsPage() {
   const { auth } = useAuth();
   const { setLanguageCode, t } = useI18n();
   const { themePreference, resolvedTheme, setThemePreference } = useTheme();
-  const { profile, aiSettings, categories, importRules, refresh } = useLedgerraData();
+  const { profile, aiSettings, categories, importRules, refresh } = useLedgerraData({
+    profile: true,
+    aiSettings: true,
+    categories: true,
+    importRules: true
+  });
   const [preferredCurrencyCode, setPreferredCurrencyCode] = useState("USD");
   const [preferredLanguageCode, setPreferredLanguageCode] = useState("en");
   const [defaultProvider, setDefaultProvider] = useState("OpenAi");

--- a/frontend/src/pages/TransactionsPage.test.tsx
+++ b/frontend/src/pages/TransactionsPage.test.tsx
@@ -8,6 +8,7 @@ const mocks = vi.hoisted(() => ({
   createTransaction: vi.fn(),
   updateTransaction: vi.fn(),
   deleteTransaction: vi.fn(),
+  moveTransactionAccount: vi.fn(),
   getTransactions: vi.fn(),
   refresh: vi.fn(),
   accounts: [
@@ -51,6 +52,7 @@ vi.mock("../api/client", () => ({
     createTransaction: mocks.createTransaction,
     updateTransaction: mocks.updateTransaction,
     deleteTransaction: mocks.deleteTransaction,
+    moveTransactionAccount: mocks.moveTransactionAccount,
     getTransactions: mocks.getTransactions
   }
 }));
@@ -105,6 +107,7 @@ describe("TransactionsPage", () => {
     mocks.createTransaction.mockResolvedValue({ id: "transaction-3" });
     mocks.updateTransaction.mockResolvedValue({ id: "transaction-4" });
     mocks.deleteTransaction.mockResolvedValue(undefined);
+    mocks.moveTransactionAccount.mockResolvedValue({ id: "transaction-1", accountId: "account-2" });
     Object.defineProperty(URL, "createObjectURL", { configurable: true, value: vi.fn() });
     Object.defineProperty(URL, "revokeObjectURL", { configurable: true, value: vi.fn() });
     vi.spyOn(URL, "createObjectURL").mockReturnValue("blob:test");
@@ -306,7 +309,7 @@ describe("TransactionsPage", () => {
     await user.click(screen.getByLabelText("Select Market"));
     await user.selectOptions(screen.getByLabelText("Move to account"), "account-2");
     await user.click(screen.getByRole("button", { name: "Move transactions" }));
-    await waitFor(() => expect(mocks.createTransaction).toHaveBeenCalledWith("token", expect.objectContaining({ accountId: "account-2" })));
+    await waitFor(() => expect(mocks.moveTransactionAccount).toHaveBeenCalledWith("token", "transaction-1", "account-2"));
   });
 
   test("deduplicates transfer group deletes in bulk actions", async () => {

--- a/frontend/src/pages/TransactionsPage.tsx
+++ b/frontend/src/pages/TransactionsPage.tsx
@@ -50,7 +50,12 @@ function getCategorisableTransactionKind(transaction: Transaction) {
 export function TransactionsPage() {
   const { auth } = useAuth();
   const { t } = useI18n();
-  const { accounts, categories, transactions, budget, refresh } = useLedgerraData();
+  const { accounts, categories, transactions, budget, refresh } = useLedgerraData({
+    accounts: true,
+    categories: true,
+    transactions: true,
+    budget: true
+  });
   const [formMode, setFormMode] = useState<TransactionFormMode>("create");
   const [editingTransactionId, setEditingTransactionId] = useState<string | null>(null);
   const [formValues, setFormValues] = useState<Partial<TransactionFormValues>>({});
@@ -417,17 +422,7 @@ export function TransactionsPage() {
     try {
       setIsApplyingBulkAction(true);
       await Promise.all(
-        targets.map(async (transaction) => {
-          await apiClient.createTransaction(auth.accessToken, {
-            accountId: bulkAccountId,
-            categoryId: transaction.categoryId ?? undefined,
-            amount: transaction.amount,
-            type: transaction.type,
-            occurredOnUtc: transaction.occurredOnUtc,
-            note: transaction.note ?? undefined
-          });
-          await apiClient.deleteTransaction(auth.accessToken!, transaction.id);
-        })
+        targets.map((transaction) => apiClient.moveTransactionAccount(auth.accessToken, transaction.id, bulkAccountId))
       );
       setStatusMessage(`Moved ${targets.length} transactions to the selected account.`);
       clearSelection();

--- a/frontend/src/state/AuthContext.tsx
+++ b/frontend/src/state/AuthContext.tsx
@@ -13,11 +13,16 @@ type AuthContextValue = {
 const STORAGE_KEY = "ledgerra.auth";
 const AuthContext = createContext<AuthContextValue | undefined>(undefined);
 
+function getAuthStorage() {
+  return window.sessionStorage;
+}
+
 export function AuthProvider({ children }: { children: ReactNode }) {
   const [auth, setAuth] = useState<AuthPayload | null>(null);
 
   useEffect(() => {
-    const raw = window.localStorage.getItem(STORAGE_KEY);
+    const raw = getAuthStorage().getItem(STORAGE_KEY);
+    window.localStorage.removeItem(STORAGE_KEY);
     if (!raw) {
       return;
     }
@@ -25,16 +30,18 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     try {
       setAuth(JSON.parse(raw) as AuthPayload);
     } catch {
-      window.localStorage.removeItem(STORAGE_KEY);
+      getAuthStorage().removeItem(STORAGE_KEY);
     }
   }, []);
+
+  useEffect(() => apiClient.onUnauthorized(() => persist(null)), []);
 
   const persist = (payload: AuthPayload | null) => {
     setAuth(payload);
     if (payload) {
-      window.localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+      getAuthStorage().setItem(STORAGE_KEY, JSON.stringify(payload));
     } else {
-      window.localStorage.removeItem(STORAGE_KEY);
+      getAuthStorage().removeItem(STORAGE_KEY);
     }
   };
 


### PR DESCRIPTION
This change introduces a new API endpoint and application logic to allow users to move an existing transaction to a different account, including support for bulk actions. It handles split transactions and prevents moving transfer transactions. Monthly account balance snapshots are refreshed for affected accounts.

In the frontend, the `useLedgerraData` hook was refactored to enable selective data loading, enhancing performance across various pages. Authentication token storage was moved from `localStorage` to `sessionStorage` for improved security, and a global unauthorized listener was added.
