### PR TITLE
Add personal API token management in settings

### DIFF
--- a/backend/src/Ledgerra.Api/Contracts/BackupContracts.cs
+++ b/backend/src/Ledgerra.Api/Contracts/BackupContracts.cs
@@ -10,7 +10,7 @@ public sealed record BackupArchiveResponse(
 
 public sealed record BackupAccountResponse(Guid Id, string Name, string Type, string CurrencyCode, decimal OpeningBalance, bool IsActive);
 
-public sealed record BackupCategoryResponse(Guid Id, string Name, string Kind, string Color);
+public sealed record BackupCategoryResponse(Guid Id, string Name, string Kind, string? Color);
 
 public sealed record BackupTransactionResponse(
     Guid Id,

--- a/backend/src/Ledgerra.Api/Contracts/PersonalAccessTokenContracts.cs
+++ b/backend/src/Ledgerra.Api/Contracts/PersonalAccessTokenContracts.cs
@@ -1,0 +1,13 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Ledgerra.Api.Contracts;
+
+public sealed record PersonalAccessTokenResponse(Guid Id, string Name, string TokenPrefix, DateTime CreatedAtUtc, DateTime? LastUsedAtUtc, DateTime? RevokedAtUtc);
+
+public sealed record CreatePersonalAccessTokenResponse(PersonalAccessTokenResponse Token, string PlainTextToken);
+
+public sealed class CreatePersonalAccessTokenRequest
+{
+    [Required, StringLength(120, MinimumLength = 3)]
+    public string Name { get; init; } = string.Empty;
+}

--- a/backend/src/Ledgerra.Api/Controllers/BackupController.cs
+++ b/backend/src/Ledgerra.Api/Controllers/BackupController.cs
@@ -50,7 +50,8 @@ public sealed class BackupController : ControllerBase
         var userId = User.GetRequiredUserId();
 
         await using var tx = await _dbContext.Database.BeginTransactionAsync(cancellationToken);
-        _dbContext.BudgetCategoryLimits.RemoveRange(_dbContext.BudgetCategoryLimits.Where(x => x.BudgetPeriod.UserId == userId));
+        var budgetPeriodIds = _dbContext.BudgetPeriods.Where(x => x.UserId == userId).Select(x => x.Id);
+        _dbContext.BudgetCategoryLimits.RemoveRange(_dbContext.BudgetCategoryLimits.Where(x => budgetPeriodIds.Contains(x.BudgetPeriodId)));
         _dbContext.BudgetPeriods.RemoveRange(_dbContext.BudgetPeriods.Where(x => x.UserId == userId));
         _dbContext.Transactions.RemoveRange(_dbContext.Transactions.Where(x => x.UserId == userId));
         _dbContext.Categories.RemoveRange(_dbContext.Categories.Where(x => x.UserId == userId));

--- a/backend/src/Ledgerra.Api/Controllers/PersonalAccessTokensController.cs
+++ b/backend/src/Ledgerra.Api/Controllers/PersonalAccessTokensController.cs
@@ -1,0 +1,81 @@
+using Ledgerra.Api.Contracts;
+using Ledgerra.Api.Extensions;
+using Ledgerra.Domain.Auth;
+using Ledgerra.Infrastructure.Authentication;
+using Ledgerra.Infrastructure.Persistence;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace Ledgerra.Api.Controllers;
+
+[ApiController]
+[Authorize]
+[Route("api/settings/personal-access-tokens")]
+public sealed class PersonalAccessTokensController : ControllerBase
+{
+    private readonly LedgerraDbContext _dbContext;
+    private readonly IJwtTokenService _jwtTokenService;
+
+    public PersonalAccessTokensController(LedgerraDbContext dbContext, IJwtTokenService jwtTokenService)
+    {
+        _dbContext = dbContext;
+        _jwtTokenService = jwtTokenService;
+    }
+
+    [HttpGet]
+    public async Task<ActionResult<IReadOnlyList<PersonalAccessTokenResponse>>> GetTokens(CancellationToken cancellationToken)
+    {
+        var userId = User.GetRequiredUserId();
+        var tokens = await _dbContext.PersonalAccessTokens
+            .Where(token => token.UserId == userId)
+            .OrderByDescending(token => token.CreatedAtUtc)
+            .Select(token => new PersonalAccessTokenResponse(token.Id, token.Name, token.TokenPrefix, token.CreatedAtUtc, token.LastUsedAtUtc, token.RevokedAtUtc))
+            .ToListAsync(cancellationToken);
+
+        return Ok(tokens);
+    }
+
+    [HttpPost]
+    public async Task<ActionResult<CreatePersonalAccessTokenResponse>> CreateToken(CreatePersonalAccessTokenRequest request, CancellationToken cancellationToken)
+    {
+        var userId = User.GetRequiredUserId();
+        var user = await _dbContext.Users.SingleOrDefaultAsync(item => item.Id == userId, cancellationToken);
+        if (user is null)
+        {
+            return NotFound();
+        }
+
+        var tokenId = Guid.NewGuid();
+        var plainTextToken = _jwtTokenService.IssuePersonalAccessToken(user, tokenId);
+        var token = new PersonalAccessToken
+        {
+            Id = tokenId,
+            UserId = user.Id,
+            Name = request.Name.Trim(),
+            TokenHash = _jwtTokenService.HashRefreshToken(plainTextToken),
+            TokenPrefix = plainTextToken[..16]
+        };
+
+        _dbContext.PersonalAccessTokens.Add(token);
+        await _dbContext.SaveChangesAsync(cancellationToken);
+
+        var response = new PersonalAccessTokenResponse(token.Id, token.Name, token.TokenPrefix, token.CreatedAtUtc, token.LastUsedAtUtc, token.RevokedAtUtc);
+        return StatusCode(StatusCodes.Status201Created, new CreatePersonalAccessTokenResponse(response, plainTextToken));
+    }
+
+    [HttpDelete("{id:guid}")]
+    public async Task<IActionResult> RevokeToken(Guid id, CancellationToken cancellationToken)
+    {
+        var userId = User.GetRequiredUserId();
+        var token = await _dbContext.PersonalAccessTokens.SingleOrDefaultAsync(item => item.Id == id && item.UserId == userId, cancellationToken);
+        if (token is null)
+        {
+            return NotFound();
+        }
+
+        token.RevokedAtUtc = DateTime.UtcNow;
+        await _dbContext.SaveChangesAsync(cancellationToken);
+        return NoContent();
+    }
+}

--- a/backend/src/Ledgerra.Api/Controllers/PersonalAccessTokensController.cs
+++ b/backend/src/Ledgerra.Api/Controllers/PersonalAccessTokensController.cs
@@ -1,3 +1,5 @@
+using System.Security.Cryptography;
+using System.Text;
 using Ledgerra.Api.Contracts;
 using Ledgerra.Api.Extensions;
 using Ledgerra.Domain.Auth;
@@ -46,15 +48,24 @@ public sealed class PersonalAccessTokensController : ControllerBase
             return NotFound();
         }
 
+        var trimmedName = request.Name?.Trim();
+        if (string.IsNullOrWhiteSpace(trimmedName))
+        {
+            ModelState.AddModelError(nameof(request.Name), "Token name cannot be empty or whitespace.");
+            return BadRequest(ModelState);
+        }
+
         var tokenId = Guid.NewGuid();
         var plainTextToken = _jwtTokenService.IssuePersonalAccessToken(user, tokenId);
+        var tokenPrefixBytes = SHA256.HashData(Encoding.UTF8.GetBytes(plainTextToken));
+        var tokenPrefix = Convert.ToHexString(tokenPrefixBytes)[..16];
         var token = new PersonalAccessToken
         {
             Id = tokenId,
             UserId = user.Id,
-            Name = request.Name.Trim(),
+            Name = trimmedName,
             TokenHash = _jwtTokenService.HashRefreshToken(plainTextToken),
-            TokenPrefix = plainTextToken[..16]
+            TokenPrefix = tokenPrefix
         };
 
         _dbContext.PersonalAccessTokens.Add(token);
@@ -74,7 +85,10 @@ public sealed class PersonalAccessTokensController : ControllerBase
             return NotFound();
         }
 
-        token.RevokedAtUtc = DateTime.UtcNow;
+        if (token.RevokedAtUtc == null)
+        {
+            token.RevokedAtUtc = DateTime.UtcNow;
+        }
         await _dbContext.SaveChangesAsync(cancellationToken);
         return NoContent();
     }

--- a/backend/src/Ledgerra.Api/Program.cs
+++ b/backend/src/Ledgerra.Api/Program.cs
@@ -15,7 +15,6 @@ using Ledgerra.Infrastructure.Security;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.IdentityModel.Tokens;
-using Microsoft.EntityFrameworkCore;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -124,8 +123,22 @@ builder.Services
                     return;
                 }
 
-                token.LastUsedAtUtc = DateTime.UtcNow;
-                await dbContext.SaveChangesAsync(context.HttpContext.RequestAborted);
+                var now = DateTime.UtcNow;
+                if (token.LastUsedAtUtc == null || (now - token.LastUsedAtUtc.Value) > TimeSpan.FromHours(1))
+                {
+                    token.LastUsedAtUtc = now;
+                    _ = Task.Run(async () =>
+                    {
+                        try
+                        {
+                            await dbContext.SaveChangesAsync();
+                        }
+                        catch
+                        {
+                            // Fail silently - token validation should not fail due to DB save errors
+                        }
+                    });
+                }
             }
         };
     });

--- a/backend/src/Ledgerra.Api/Program.cs
+++ b/backend/src/Ledgerra.Api/Program.cs
@@ -15,6 +15,7 @@ using Ledgerra.Infrastructure.Security;
 using Microsoft.AspNetCore.Authentication.JwtBearer;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.IdentityModel.Tokens;
+using Microsoft.EntityFrameworkCore;
 
 var builder = WebApplication.CreateBuilder(args);
 
@@ -104,6 +105,28 @@ builder.Services
             ValidAudience = authOptions.Audience,
             IssuerSigningKey = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(authOptions.SigningKey)),
             ClockSkew = TimeSpan.FromSeconds(30)
+        };
+        options.Events = new JwtBearerEvents
+        {
+            OnTokenValidated = async context =>
+            {
+                var patId = context.Principal?.FindFirst("pat_id")?.Value;
+                if (string.IsNullOrWhiteSpace(patId) || !Guid.TryParse(patId, out var parsedPatId))
+                {
+                    return;
+                }
+
+                var dbContext = context.HttpContext.RequestServices.GetRequiredService<LedgerraDbContext>();
+                var token = await dbContext.PersonalAccessTokens.SingleOrDefaultAsync(item => item.Id == parsedPatId);
+                if (token is null || token.RevokedAtUtc is not null)
+                {
+                    context.Fail("Token revoked.");
+                    return;
+                }
+
+                token.LastUsedAtUtc = DateTime.UtcNow;
+                await dbContext.SaveChangesAsync(context.HttpContext.RequestAborted);
+            }
         };
     });
 

--- a/backend/src/Ledgerra.Domain/Auth/AppUser.cs
+++ b/backend/src/Ledgerra.Domain/Auth/AppUser.cs
@@ -34,6 +34,8 @@ public sealed class AppUser
 
     public List<RefreshToken> RefreshTokens { get; set; } = [];
 
+    public List<PersonalAccessToken> PersonalAccessTokens { get; set; } = [];
+
     public List<AiProviderCredential> AiProviderCredentials { get; set; } = [];
 
     public List<CategorizationRule> CategorizationRules { get; set; } = [];

--- a/backend/src/Ledgerra.Domain/Auth/PersonalAccessToken.cs
+++ b/backend/src/Ledgerra.Domain/Auth/PersonalAccessToken.cs
@@ -1,0 +1,22 @@
+namespace Ledgerra.Domain.Auth;
+
+public sealed class PersonalAccessToken
+{
+    public Guid Id { get; set; }
+
+    public Guid UserId { get; set; }
+
+    public AppUser User { get; set; } = null!;
+
+    public string Name { get; set; } = string.Empty;
+
+    public string TokenHash { get; set; } = string.Empty;
+
+    public string TokenPrefix { get; set; } = string.Empty;
+
+    public DateTime CreatedAtUtc { get; set; } = DateTime.UtcNow;
+
+    public DateTime? RevokedAtUtc { get; set; }
+
+    public DateTime? LastUsedAtUtc { get; set; }
+}

--- a/backend/src/Ledgerra.Infrastructure/Authentication/AuthOptions.cs
+++ b/backend/src/Ledgerra.Infrastructure/Authentication/AuthOptions.cs
@@ -13,4 +13,6 @@ public sealed class AuthOptions
     public int AccessTokenMinutes { get; set; } = 60;
 
     public int RefreshTokenDays { get; set; } = 30;
+
+    public TimeSpan PersonalAccessTokenLifetime { get; set; } = TimeSpan.FromDays(365);
 }

--- a/backend/src/Ledgerra.Infrastructure/Authentication/IJwtTokenService.cs
+++ b/backend/src/Ledgerra.Infrastructure/Authentication/IJwtTokenService.cs
@@ -7,4 +7,6 @@ public interface IJwtTokenService
     IssuedAuthToken IssueToken(AppUser user);
 
     string HashRefreshToken(string refreshToken);
+
+    string IssuePersonalAccessToken(AppUser user, Guid personalAccessTokenId);
 }

--- a/backend/src/Ledgerra.Infrastructure/Authentication/JwtTokenService.cs
+++ b/backend/src/Ledgerra.Infrastructure/Authentication/JwtTokenService.cs
@@ -62,7 +62,7 @@ public sealed class JwtTokenService : IJwtTokenService
 
         var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(_options.SigningKey));
         var credentials = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
-        var token = new JwtSecurityToken(_options.Issuer, _options.Audience, claims, now, now.AddYears(10), credentials);
+        var token = new JwtSecurityToken(_options.Issuer, _options.Audience, claims, now, now.Add(_options.PersonalAccessTokenLifetime), credentials);
         return new JwtSecurityTokenHandler().WriteToken(token);
     }
 

--- a/backend/src/Ledgerra.Infrastructure/Authentication/JwtTokenService.cs
+++ b/backend/src/Ledgerra.Infrastructure/Authentication/JwtTokenService.cs
@@ -49,6 +49,23 @@ public sealed class JwtTokenService : IJwtTokenService
             expiresAt);
     }
 
+
+    public string IssuePersonalAccessToken(AppUser user, Guid personalAccessTokenId)
+    {
+        var now = DateTime.UtcNow;
+        var claims = new List<Claim>
+        {
+            new(JwtRegisteredClaimNames.Sub, user.Id.ToString()),
+            new(ClaimTypes.NameIdentifier, user.Id.ToString()),
+            new("pat_id", personalAccessTokenId.ToString())
+        };
+
+        var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(_options.SigningKey));
+        var credentials = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
+        var token = new JwtSecurityToken(_options.Issuer, _options.Audience, claims, now, now.AddYears(10), credentials);
+        return new JwtSecurityTokenHandler().WriteToken(token);
+    }
+
     public string HashRefreshToken(string refreshToken)
     {
         var bytes = SHA256.HashData(Encoding.UTF8.GetBytes(refreshToken));

--- a/backend/src/Ledgerra.Infrastructure/Persistence/LedgerraDbContext.cs
+++ b/backend/src/Ledgerra.Infrastructure/Persistence/LedgerraDbContext.cs
@@ -35,6 +35,8 @@ public sealed class LedgerraDbContext : DbContext
 
     public DbSet<RefreshToken> RefreshTokens => Set<RefreshToken>();
 
+    public DbSet<PersonalAccessToken> PersonalAccessTokens => Set<PersonalAccessToken>();
+
     public DbSet<AiProviderCredential> AiProviderCredentials => Set<AiProviderCredential>();
 
     public DbSet<UserAiPreference> UserAiPreferences => Set<UserAiPreference>();
@@ -173,6 +175,21 @@ public sealed class LedgerraDbContext : DbContext
             builder.HasIndex(token => token.TokenHash).IsUnique();
             builder.HasOne(token => token.User)
                 .WithMany(user => user.RefreshTokens)
+                .HasForeignKey(token => token.UserId)
+                .OnDelete(DeleteBehavior.Cascade);
+        });
+
+
+        modelBuilder.Entity<PersonalAccessToken>(builder =>
+        {
+            builder.HasKey(token => token.Id);
+            builder.Property(token => token.Name).HasMaxLength(120);
+            builder.Property(token => token.TokenHash).HasMaxLength(128);
+            builder.Property(token => token.TokenPrefix).HasMaxLength(16);
+            builder.HasIndex(token => token.TokenHash).IsUnique();
+            builder.HasIndex(token => new { token.UserId, token.Name });
+            builder.HasOne(token => token.User)
+                .WithMany(user => user.PersonalAccessTokens)
                 .HasForeignKey(token => token.UserId)
                 .OnDelete(DeleteBehavior.Cascade);
         });

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -13,7 +13,9 @@ import type {
   ReportingRangePreset,
   BackupArchive,
   Transaction,
-  SavingsGoal
+  SavingsGoal,
+  PersonalAccessToken,
+  CreatePersonalAccessTokenResponse
 } from "../types";
 
 const API_BASE_URL = import.meta.env.VITE_API_BASE_URL ?? "";
@@ -167,6 +169,24 @@ export const apiClient = {
       body: { provider }
     });
   },
+
+  getPersonalAccessTokens(token: string) {
+    return request<PersonalAccessToken[]>("/api/settings/personal-access-tokens", { token });
+  },
+  createPersonalAccessToken(token: string, name: string) {
+    return request<CreatePersonalAccessTokenResponse>("/api/settings/personal-access-tokens", {
+      method: "POST",
+      token,
+      body: { name }
+    });
+  },
+  revokePersonalAccessToken(token: string, id: string) {
+    return request<void>(`/api/settings/personal-access-tokens/${id}`, {
+      method: "DELETE",
+      token
+    });
+  },
+
   getCategories(token: string) {
     return request<Category[]>("/api/categories", { token });
   },

--- a/frontend/src/pages/SettingsPage.test.tsx
+++ b/frontend/src/pages/SettingsPage.test.tsx
@@ -10,6 +10,9 @@ const mocks = vi.hoisted(() => ({
   saveAiProviderKey: vi.fn(),
   removeAiProviderKey: vi.fn(),
   updateDefaultAiProvider: vi.fn(),
+  getPersonalAccessTokens: vi.fn(),
+  createPersonalAccessToken: vi.fn(),
+  revokePersonalAccessToken: vi.fn(),
   createImportRule: vi.fn(),
   updateImportRule: vi.fn(),
   deleteImportRule: vi.fn(),
@@ -32,6 +35,9 @@ vi.mock("../api/client", () => ({
     saveAiProviderKey: mocks.saveAiProviderKey,
     removeAiProviderKey: mocks.removeAiProviderKey,
     updateDefaultAiProvider: mocks.updateDefaultAiProvider,
+    getPersonalAccessTokens: mocks.getPersonalAccessTokens,
+    createPersonalAccessToken: mocks.createPersonalAccessToken,
+    revokePersonalAccessToken: mocks.revokePersonalAccessToken,
     createImportRule: mocks.createImportRule,
     updateImportRule: mocks.updateImportRule,
     deleteImportRule: mocks.deleteImportRule
@@ -74,6 +80,9 @@ describe("SettingsPage", () => {
     mocks.aiSettings.providers.openAi = { isConfigured: true, maskedKey: "...3456" };
     mocks.aiSettings.providers.anthropic = { isConfigured: false, maskedKey: null };
     mocks.aiSettings.defaultProvider = "OpenAi";
+    mocks.getPersonalAccessTokens.mockResolvedValue([]);
+    mocks.createPersonalAccessToken.mockResolvedValue({ plainTextToken: "ledgerra_pat_test" });
+    mocks.revokePersonalAccessToken.mockResolvedValue(undefined);
   });
 
   test("shows AI provider configuration state", () => {

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -1,4 +1,4 @@
-import { ChangeEvent, FormEvent, useEffect, useMemo, useState } from "react";
+import { ChangeEvent, FormEvent, useCallback, useEffect, useMemo, useState } from "react";
 import { apiClient } from "../api/client";
 import { useLedgerraData } from "../hooks/useLedgerraData";
 import { useAuth } from "../state/AuthContext";
@@ -179,14 +179,14 @@ export function SettingsPage() {
     }
   };
 
-  const loadPersonalAccessTokens = async () => {
+  const loadPersonalAccessTokens = useCallback(async () => {
     if (!auth?.accessToken) {
       return;
     }
 
     const tokens = await apiClient.getPersonalAccessTokens(auth.accessToken);
     setPersonalAccessTokens(tokens);
-  };
+  }, [auth?.accessToken]);
 
   const handleCreatePersonalAccessToken = async (event: FormEvent) => {
     event.preventDefault();
@@ -211,7 +211,7 @@ export function SettingsPage() {
 
   useEffect(() => {
     loadPersonalAccessTokens();
-  }, [auth?.accessToken]);
+  }, [loadPersonalAccessTokens]);
 
   const isOpenAiConfigured = !!aiSettings?.providers.openAi.maskedKey;
   const isAnthropicConfigured = !!aiSettings?.providers.anthropic.maskedKey;

--- a/frontend/src/pages/SettingsPage.tsx
+++ b/frontend/src/pages/SettingsPage.tsx
@@ -4,7 +4,7 @@ import { useLedgerraData } from "../hooks/useLedgerraData";
 import { useAuth } from "../state/AuthContext";
 import { useI18n } from "../state/I18nContext";
 import { useTheme, type ThemePreference } from "../state/ThemeContext";
-import type { ImportRule } from "../types";
+import type { ImportRule, PersonalAccessToken } from "../types";
 import { PageHeader } from "../ui/PageHeader";
 import { SectionCard } from "../ui/SectionCard";
 import { normalizeCurrencyCode, supportedCurrencies } from "../utils/currency";
@@ -37,6 +37,9 @@ export function SettingsPage() {
   const [ruleError, setRuleError] = useState<string | null>(null);
   const [backupError, setBackupError] = useState<string | null>(null);
   const [backupNotice, setBackupNotice] = useState<string | null>(null);
+  const [personalAccessTokens, setPersonalAccessTokens] = useState<PersonalAccessToken[]>([]);
+  const [newTokenName, setNewTokenName] = useState("");
+  const [createdToken, setCreatedToken] = useState<string | null>(null);
 
   const filteredCategories = useMemo(() => categories.filter((category) => category.kind === transactionType), [categories, transactionType]);
 
@@ -175,6 +178,40 @@ export function SettingsPage() {
       setRuleError(getErrorMessage(exception, t("settings.unableToDeleteRule")));
     }
   };
+
+  const loadPersonalAccessTokens = async () => {
+    if (!auth?.accessToken) {
+      return;
+    }
+
+    const tokens = await apiClient.getPersonalAccessTokens(auth.accessToken);
+    setPersonalAccessTokens(tokens);
+  };
+
+  const handleCreatePersonalAccessToken = async (event: FormEvent) => {
+    event.preventDefault();
+    if (!auth?.accessToken || !newTokenName.trim()) {
+      return;
+    }
+
+    const response = await apiClient.createPersonalAccessToken(auth.accessToken, newTokenName.trim());
+    setCreatedToken(response.plainTextToken);
+    setNewTokenName("");
+    await loadPersonalAccessTokens();
+  };
+
+  const handleRevokePersonalAccessToken = async (id: string) => {
+    if (!auth?.accessToken) {
+      return;
+    }
+
+    await apiClient.revokePersonalAccessToken(auth.accessToken, id);
+    await loadPersonalAccessTokens();
+  };
+
+  useEffect(() => {
+    loadPersonalAccessTokens();
+  }, [auth?.accessToken]);
 
   const isOpenAiConfigured = !!aiSettings?.providers.openAi.maskedKey;
   const isAnthropicConfigured = !!aiSettings?.providers.anthropic.maskedKey;

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -225,3 +225,18 @@ export type BackupArchive = {
     categoryLimits: Array<{ id: string; categoryId: string; plannedAmount: number }>;
   }>;
 };
+
+
+export type PersonalAccessToken = {
+  id: string;
+  name: string;
+  tokenPrefix: string;
+  createdAtUtc: string;
+  lastUsedAtUtc?: string | null;
+  revokedAtUtc?: string | null;
+};
+
+export type CreatePersonalAccessTokenResponse = {
+  token: PersonalAccessToken;
+  plainTextToken: string;
+};


### PR DESCRIPTION
### Motivation
- Provide users the ability to generate and revoke named personal API tokens that carry the same API privileges as their session for scripts, CLI tools and third-party integrations.
- Persist token metadata and support secure verification and revocation without exposing plaintext tokens after creation.

### Description
- Added a `PersonalAccessToken` domain entity and wired it into `AppUser` and `LedgerraDbContext` with EF Core mapping and indices, storing `TokenHash`, `TokenPrefix`, `CreatedAtUtc`, `LastUsedAtUtc`, and `RevokedAtUtc`.
- Implemented authenticated settings endpoints at `/api/settings/personal-access-tokens` with `GET` to list tokens, `POST` to create a named token (returns one-time plaintext token), and `DELETE /{id}` to revoke a token using `PersonalAccessTokenContracts` and `PersonalAccessTokensController`.
- Extended `IJwtTokenService`/`JwtTokenService` with `IssuePersonalAccessToken` to emit a long-lived JWT carrying a `pat_id` claim and continued use of SHA-256 hashing (`HashRefreshToken`) to persist token hashes and a stored token prefix for UX.
- Added runtime validation in `Program.cs` `JwtBearer` events to detect `pat_id` tokens, enforce revocation checks, and update `LastUsedAtUtc` on use, and added frontend changes (types, `apiClient` methods, and a new Settings UI section) to create, display (one-time), list and revoke tokens.

### Testing
- Attempted to build the backend with `dotnet build backend/Ledgerra.sln`, which failed in this environment because `dotnet` is not installed.
- Attempted frontend build with `cd frontend && npm run build`, which failed in this environment due to missing TypeScript type packages and existing tsconfig warnings unrelated to these changes.
- No automated unit/integration tests were executed successfully in this environment due to the toolchain limitations above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fefac18c308324a7c9d53b0be46af7)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Personal access token management added to Settings—create, list, and revoke PATs.
  * Created tokens show the plaintext once, and tokens surface metadata (name, created at, last-used, revoked) with last-used timestamps tracked and updated on use.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/soliktomasz/Ledgerra/pull/47)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->