### PR TITLE
LOW-28: Preserve full domain graph in backup archive (v3)

### DIFF
--- a/backend/src/Ledgerra.Api/Contracts/BackupContracts.cs
+++ b/backend/src/Ledgerra.Api/Contracts/BackupContracts.cs
@@ -6,9 +6,19 @@ public sealed record BackupArchiveResponse(
     IReadOnlyList<BackupAccountResponse> Accounts,
     IReadOnlyList<BackupCategoryResponse> Categories,
     IReadOnlyList<BackupTransactionResponse> Transactions,
-    IReadOnlyList<BackupBudgetPeriodResponse> BudgetPeriods);
+    IReadOnlyList<BackupBudgetPeriodResponse> BudgetPeriods,
+    IReadOnlyList<BackupSavingsGoalResponse>? SavingsGoals = null);
 
-public sealed record BackupAccountResponse(Guid Id, string Name, string Type, string CurrencyCode, decimal OpeningBalance, bool IsActive);
+public sealed record BackupAccountResponse(
+    Guid Id,
+    string Name,
+    string Type,
+    string CurrencyCode,
+    decimal OpeningBalance,
+    bool IsActive,
+    string? InstitutionName = null,
+    string? AccountNumberMasked = null,
+    string IconKind = "Bank");
 
 public sealed record BackupCategoryResponse(Guid Id, string Name, string Kind, string? Color);
 
@@ -22,8 +32,12 @@ public sealed record BackupTransactionResponse(
     string? Note,
     Guid? TransferGroupId,
     Guid? SplitGroupId = null,
-    Guid? ParentTransactionId = null);
+    Guid? ParentTransactionId = null,
+    Guid? SavingsGoalId = null);
 
 public sealed record BackupBudgetPeriodResponse(Guid Id, int Year, int Month, IReadOnlyList<BackupBudgetCategoryLimitResponse> CategoryLimits);
 
 public sealed record BackupBudgetCategoryLimitResponse(Guid Id, Guid CategoryId, decimal PlannedAmount, bool CarryOverUnspent = false);
+
+
+public sealed record BackupSavingsGoalResponse(Guid Id, string Name, decimal TargetAmount, string? DeadlineUtc = null, string? CreatedAtUtc = null, string? UpdatedAtUtc = null);

--- a/backend/src/Ledgerra.Api/Controllers/BackupController.cs
+++ b/backend/src/Ledgerra.Api/Controllers/BackupController.cs
@@ -31,23 +31,31 @@ public sealed class BackupController : ControllerBase
             .ThenBy(x => x.Month)
             .ToListAsync(cancellationToken);
 
+        var savingsGoals = await _dbContext.SavingsGoals.Where(x => x.UserId == userId).OrderBy(x => x.CreatedAtUtc).ToListAsync(cancellationToken);
+
         return Ok(new BackupArchiveResponse(
-            2,
+            3,
             DateTimeOffset.UtcNow.ToString("O"),
-            accounts.Select(x => new BackupAccountResponse(x.Id, x.Name, x.Type.ToString(), x.CurrencyCode, x.OpeningBalance, x.IsActive)).ToList(),
+            accounts.Select(x => new BackupAccountResponse(x.Id, x.Name, x.Type.ToString(), x.CurrencyCode, x.OpeningBalance, x.IsActive, x.InstitutionName, x.AccountNumberMasked, x.IconKind.ToString())).ToList(),
             categories.Select(x => new BackupCategoryResponse(x.Id, x.Name, x.Kind.ToString(), x.Color)).ToList(),
-            transactions.Select(x => new BackupTransactionResponse(x.Id, x.AccountId, x.CategoryId, x.Amount, x.Type.ToString(), x.OccurredOnUtc.ToString("O"), x.Note, x.TransferGroupId, x.SplitGroupId, x.ParentTransactionId)).ToList(),
+            transactions.Select(x => new BackupTransactionResponse(x.Id, x.AccountId, x.CategoryId, x.Amount, x.Type.ToString(), x.OccurredOnUtc.ToString("O"), x.Note, x.TransferGroupId, x.SplitGroupId, x.ParentTransactionId, x.SavingsGoalId)).ToList(),
             budgetPeriods.Select(x => new BackupBudgetPeriodResponse(
                 x.Id,
                 x.Year,
                 x.Month,
-                x.CategoryLimits.Select(limit => new BackupBudgetCategoryLimitResponse(limit.Id, limit.CategoryId, limit.PlannedAmount, limit.CarryOverUnspent)).ToList())).ToList()));
+                x.CategoryLimits.Select(limit => new BackupBudgetCategoryLimitResponse(limit.Id, limit.CategoryId, limit.PlannedAmount, limit.CarryOverUnspent)).ToList())).ToList(),
+            savingsGoals.Select(x => new BackupSavingsGoalResponse(x.Id, x.Name, x.TargetAmount, x.DeadlineUtc?.ToString("O"), x.CreatedAtUtc.ToString("O"), x.UpdatedAtUtc.ToString("O"))).ToList()));
     }
 
     [HttpPost("restore")]
     public async Task<ActionResult> Restore([FromBody] BackupArchiveResponse archive, CancellationToken cancellationToken)
     {
         var userId = User.GetRequiredUserId();
+
+        if (archive.Version is < 2 or > 3)
+        {
+            return BadRequest(new ProblemDetails { Title = "Unsupported backup archive version." });
+        }
 
         var referenceError = ValidateArchiveReferences(archive);
         if (referenceError is not null)
@@ -62,6 +70,7 @@ public sealed class BackupController : ControllerBase
         _dbContext.Transactions.RemoveRange(_dbContext.Transactions.Where(x => x.UserId == userId));
         _dbContext.Categories.RemoveRange(_dbContext.Categories.Where(x => x.UserId == userId));
         _dbContext.Accounts.RemoveRange(_dbContext.Accounts.Where(x => x.UserId == userId));
+        _dbContext.SavingsGoals.RemoveRange(_dbContext.SavingsGoals.Where(x => x.UserId == userId));
         await _dbContext.SaveChangesAsync(cancellationToken);
 
         var accounts = archive.Accounts.Select(x => new Ledgerra.Domain.Accounts.Account
@@ -72,7 +81,10 @@ public sealed class BackupController : ControllerBase
             Type = Enum.Parse<Ledgerra.Domain.Accounts.AccountType>(x.Type),
             CurrencyCode = x.CurrencyCode,
             OpeningBalance = x.OpeningBalance,
-            IsActive = x.IsActive
+            IsActive = x.IsActive,
+            InstitutionName = x.InstitutionName,
+            AccountNumberMasked = x.AccountNumberMasked,
+            IconKind = Enum.Parse<Ledgerra.Domain.Accounts.AccountIconKind>(x.IconKind)
         }).ToList();
         var categories = archive.Categories.Select(x => new Ledgerra.Domain.Categories.Category
         {
@@ -94,8 +106,20 @@ public sealed class BackupController : ControllerBase
             Note = x.Note,
             TransferGroupId = x.TransferGroupId,
             SplitGroupId = x.SplitGroupId,
-            ParentTransactionId = x.ParentTransactionId
+            ParentTransactionId = x.ParentTransactionId,
+            SavingsGoalId = x.SavingsGoalId
         }).ToList();
+        var savingsGoals = (archive.SavingsGoals ?? []).Select(x => new Ledgerra.Domain.Goals.SavingsGoal
+        {
+            Id = x.Id,
+            UserId = userId,
+            Name = x.Name,
+            TargetAmount = x.TargetAmount,
+            DeadlineUtc = string.IsNullOrWhiteSpace(x.DeadlineUtc) ? null : DateTime.Parse(x.DeadlineUtc),
+            CreatedAtUtc = string.IsNullOrWhiteSpace(x.CreatedAtUtc) ? DateTime.UtcNow : DateTime.Parse(x.CreatedAtUtc),
+            UpdatedAtUtc = string.IsNullOrWhiteSpace(x.UpdatedAtUtc) ? DateTime.UtcNow : DateTime.Parse(x.UpdatedAtUtc)
+        }).ToList();
+
         var periods = archive.BudgetPeriods.Select(x => new Ledgerra.Domain.Budgets.BudgetPeriod
         {
             Id = x.Id,
@@ -114,6 +138,7 @@ public sealed class BackupController : ControllerBase
 
         await _dbContext.Accounts.AddRangeAsync(accounts, cancellationToken);
         await _dbContext.Categories.AddRangeAsync(categories, cancellationToken);
+        await _dbContext.SavingsGoals.AddRangeAsync(savingsGoals, cancellationToken);
         await _dbContext.Transactions.AddRangeAsync(transactions, cancellationToken);
         await _dbContext.BudgetPeriods.AddRangeAsync(periods, cancellationToken);
         await _dbContext.BudgetCategoryLimits.AddRangeAsync(limits, cancellationToken);
@@ -128,6 +153,7 @@ public sealed class BackupController : ControllerBase
         var accountIds = new HashSet<Guid>(archive.Accounts.Select(a => a.Id));
         var categoryIds = new HashSet<Guid>(archive.Categories.Select(c => c.Id));
         var transactionIds = new HashSet<Guid>(archive.Transactions.Select(t => t.Id));
+        var savingsGoalIds = new HashSet<Guid>((archive.SavingsGoals ?? []).Select(goal => goal.Id));
 
         foreach (var transaction in archive.Transactions)
         {
@@ -144,6 +170,11 @@ public sealed class BackupController : ControllerBase
             if (transaction.ParentTransactionId.HasValue && !transactionIds.Contains(transaction.ParentTransactionId.Value))
             {
                 return "Backup contains a transaction referencing a parent transaction not present in the archive.";
+            }
+
+            if (transaction.SavingsGoalId.HasValue && !savingsGoalIds.Contains(transaction.SavingsGoalId.Value))
+            {
+                return "Backup contains a transaction referencing a savings goal not present in the archive.";
             }
         }
 

--- a/backend/tests/Ledgerra.Api.Tests/BackupRestoreSecurityTests.cs
+++ b/backend/tests/Ledgerra.Api.Tests/BackupRestoreSecurityTests.cs
@@ -150,6 +150,41 @@ public sealed class BackupRestoreSecurityTests : IClassFixture<LedgerraApiFactor
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
 
+
+    [Fact]
+    public async Task Restore_RejectsTransactionReferencingForeignSavingsGoalId()
+    {
+        using var client = _factory.CreateClient();
+        var auth = await RegisterAndAuthenticateAsync(client);
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", auth);
+
+        var accountId = Guid.NewGuid();
+        var foreignSavingsGoalId = Guid.NewGuid();
+
+        var archive = new
+        {
+            version = 3,
+            exportedAtUtc = "2025-01-01T00:00:00Z",
+            accounts = new[] { new { id = accountId, name = "My Account", type = "Checking", currencyCode = "USD", openingBalance = 0m, isActive = true } },
+            categories = Array.Empty<object>(),
+            transactions = new[]
+            {
+                new
+                {
+                    id = Guid.NewGuid(), accountId, categoryId = (Guid?)null,
+                    amount = 50m, type = "Income", occurredOnUtc = "2025-02-01T00:00:00Z",
+                    note = (string?)null, transferGroupId = (Guid?)null, splitGroupId = (Guid?)null, parentTransactionId = (Guid?)null, savingsGoalId = (Guid?)foreignSavingsGoalId
+                }
+            },
+            budgetPeriods = Array.Empty<object>(),
+            savingsGoals = Array.Empty<object>()
+        };
+
+        var response = await client.PostAsJsonAsync("/api/backup/restore", archive);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
     [Fact]
     public async Task Restore_AcceptsValidSelfContainedArchive()
     {
@@ -258,3 +293,57 @@ public sealed class BackupRestoreSecurityTests : IClassFixture<LedgerraApiFactor
         return payload.GetProperty("accessToken").GetString()!;
     }
 }
+
+    [Fact]
+    public async Task ExportAndRestore_PreservesSavingsGoalsAndAccountMetadata()
+    {
+        using var client = _factory.CreateClient();
+        var auth = await RegisterAndAuthenticateAsync(client);
+        client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", auth);
+
+        var accountResponse = await client.PostAsJsonAsync("/api/accounts", new
+        {
+            name = "Primary",
+            type = "Checking",
+            currencyCode = "USD",
+            openingBalance = 12m,
+            institutionName = "Credit Union",
+            accountNumberMasked = "****1234",
+            iconKind = "Wallet"
+        });
+        Assert.Equal(HttpStatusCode.Created, accountResponse.StatusCode);
+
+        var goalResponse = await client.PostAsJsonAsync("/api/savings-goals", new
+        {
+            name = "Emergency",
+            targetAmount = 1000m,
+            deadlineUtc = "2026-12-31T00:00:00Z"
+        });
+        Assert.Equal(HttpStatusCode.Created, goalResponse.StatusCode);
+        var goalPayload = await goalResponse.Content.ReadFromJsonAsync<JsonElement>();
+        var goalId = goalPayload.GetProperty("id").GetGuid();
+
+        var accountPayload = await accountResponse.Content.ReadFromJsonAsync<JsonElement>();
+        var accountId = accountPayload.GetProperty("id").GetGuid();
+
+        var txResponse = await client.PostAsJsonAsync("/api/transactions", new
+        {
+            accountId,
+            amount = 100m,
+            type = "Income",
+            occurredOnUtc = "2026-01-01T00:00:00Z",
+            savingsGoalId = goalId
+        });
+        Assert.Equal(HttpStatusCode.Created, txResponse.StatusCode);
+
+        var exportResponse = await client.GetAsync("/api/backup/export");
+        Assert.Equal(HttpStatusCode.OK, exportResponse.StatusCode);
+        var archive = await exportResponse.Content.ReadFromJsonAsync<JsonElement>();
+        Assert.Equal(3, archive.GetProperty("version").GetInt32());
+        Assert.Equal("Credit Union", archive.GetProperty("accounts")[0].GetProperty("institutionName").GetString());
+        Assert.Equal(goalId, archive.GetProperty("transactions")[0].GetProperty("savingsGoalId").GetGuid());
+        Assert.Equal(goalId, archive.GetProperty("savingsGoals")[0].GetProperty("id").GetGuid());
+
+        var restoreResponse = await client.PostAsJsonAsync("/api/backup/restore", archive);
+        Assert.Equal(HttpStatusCode.NoContent, restoreResponse.StatusCode);
+    }

--- a/backend/tests/Ledgerra.Api.Tests/BackupRestoreSecurityTests.cs
+++ b/backend/tests/Ledgerra.Api.Tests/BackupRestoreSecurityTests.cs
@@ -292,8 +292,6 @@ public sealed class BackupRestoreSecurityTests : IClassFixture<LedgerraApiFactor
         var payload = await response.Content.ReadFromJsonAsync<JsonElement>();
         return payload.GetProperty("accessToken").GetString()!;
     }
-}
-
     [Fact]
     public async Task ExportAndRestore_PreservesSavingsGoalsAndAccountMetadata()
     {
@@ -309,7 +307,7 @@ public sealed class BackupRestoreSecurityTests : IClassFixture<LedgerraApiFactor
             openingBalance = 12m,
             institutionName = "Credit Union",
             accountNumberMasked = "****1234",
-            iconKind = "Wallet"
+            iconKind = "Cash"
         });
         Assert.Equal(HttpStatusCode.Created, accountResponse.StatusCode);
 
@@ -341,9 +339,11 @@ public sealed class BackupRestoreSecurityTests : IClassFixture<LedgerraApiFactor
         var archive = await exportResponse.Content.ReadFromJsonAsync<JsonElement>();
         Assert.Equal(3, archive.GetProperty("version").GetInt32());
         Assert.Equal("Credit Union", archive.GetProperty("accounts")[0].GetProperty("institutionName").GetString());
+        Assert.Equal("Cash", archive.GetProperty("accounts")[0].GetProperty("iconKind").GetString());
         Assert.Equal(goalId, archive.GetProperty("transactions")[0].GetProperty("savingsGoalId").GetGuid());
         Assert.Equal(goalId, archive.GetProperty("savingsGoals")[0].GetProperty("id").GetGuid());
 
         var restoreResponse = await client.PostAsJsonAsync("/api/backup/restore", archive);
         Assert.Equal(HttpStatusCode.NoContent, restoreResponse.StatusCode);
     }
+}

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -202,6 +202,9 @@ export type BackupAccount = {
   currencyCode: string;
   openingBalance: number;
   isActive: boolean;
+  institutionName?: string | null;
+  accountNumberMasked?: string | null;
+  iconKind?: string;
 };
 
 export type BackupCategory = {
@@ -233,7 +236,15 @@ export type BackupArchive = {
     id: string;
     year: number;
     month: number;
-    categoryLimits: Array<{ id: string; categoryId: string; plannedAmount: number }>;
+    categoryLimits: Array<{ id: string; categoryId: string; plannedAmount: number; carryOverUnspent?: boolean }>;
+  }>;
+  savingsGoals?: Array<{
+    id: string;
+    name: string;
+    targetAmount: number;
+    deadlineUtc?: string | null;
+    createdAtUtc?: string | null;
+    updatedAtUtc?: string | null;
   }>;
 };
 


### PR DESCRIPTION
### Motivation
- The existing backup/restore flow missed domain data introduced later (savings goals, transaction → `savingsGoalId`, and account metadata), causing data loss during round-trip backups.
- Frontend typings for the backup archive were out of sync with the backend contract (notably `carryOverUnspent` and missing `savingsGoals`), risking runtime errors and incomplete restores.

### Description
- Bumped backup archive `version` from `2` to `3` and extended the backend contract in `BackupContracts.cs` to include `savingsGoals`, transaction `savingsGoalId`, and account metadata fields (`institutionName`, `accountNumberMasked`, `iconKind`).
- Updated `BackupController` export to include `SavingsGoals` and account metadata, and updated restore to accept archives `version` 2 and 3, validate savings-goal references, recreate savings goals, preserve account metadata, and rehydrate transaction savings-goal links while recreating the full graph.
- Updated frontend typing in `frontend/src/types.ts` to match the expanded archive shape (optional `savingsGoals`, `savingsGoalId`, enriched `BackupAccount` fields, and `carryOverUnspent` in budget category limits).
- Added API tests in `BackupRestoreSecurityTests.cs` covering rejection of archives that reference missing savings goals and a round-trip test that asserts preservation of savings goals and account metadata.

### Testing
- Attempted to run the API tests with `dotnet test backend/tests/Ledgerra.Api.Tests/Ledgerra.Api.Tests.csproj`, but the `dotnet` SDK is not available in this environment so the test run could not be executed here.
- New unit tests were added to `backend/tests/Ledgerra.Api.Tests/BackupRestoreSecurityTests.cs` and should be executed in CI or a local environment with the .NET SDK; they are intended to validate reference checks and round-trip preservation.
- No other automated test runs were executed in this environment due to the tooling limitation described above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a09784085c88324be907ab9820f5d8d)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Backup export now includes savings goals data
  * Backup captures additional account details (institution name, masked account numbers)
  * Savings goal associations with transactions are preserved during restore
  * Backup format updated to version 3 with backward compatibility

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/soliktomasz/Ledgerra/pull/73?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->