### PR TITLE
LOW-33: Frontend access-token refresh with single-flight retry and auth persistence

### DIFF
--- a/frontend/src/api/client.test.ts
+++ b/frontend/src/api/client.test.ts
@@ -48,4 +48,69 @@ describe("apiClient", () => {
       password: "P@ssw0rd123!"
     });
   });
+
+  it("refreshes once and retries concurrent unauthorized requests", async () => {
+    const persist = vi.fn();
+    apiClient.setAuthHandlers(
+      () => ({
+        userId: "user-1",
+        login: "owner",
+        email: "owner@test.local",
+        accessToken: "expired-token",
+        refreshToken: "refresh-token",
+        expiresAtUtc: "2999-01-01T00:00:00Z"
+      }),
+      persist
+    );
+
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({ ok: false, status: 401, clone: () => ({ json: async () => ({ title: "expired" }) }), text: async () => "expired" })
+      .mockResolvedValueOnce({ ok: false, status: 401, clone: () => ({ json: async () => ({ title: "expired" }) }), text: async () => "expired" })
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          userId: "user-1", login: "owner", email: "owner@test.local", accessToken: "fresh-token", refreshToken: "rotated", expiresAtUtc: "2999-01-02T00:00:00Z"
+        })
+      })
+      .mockResolvedValue({ ok: true, status: 200, json: async () => ({ value: 1 }) });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await Promise.all([
+      apiClient.getDashboard("expired-token", "2026-05"),
+      apiClient.getAccounts("expired-token")
+    ]);
+
+    const refreshCalls = fetchMock.mock.calls.filter((call) => (call[0] as string).includes("/api/auth/refresh"));
+    expect(refreshCalls).toHaveLength(1);
+    expect(persist).toHaveBeenCalledWith(expect.objectContaining({ accessToken: "fresh-token", refreshToken: "rotated" }));
+  });
+
+  it("notifies unauthorized and does not retry loop when refresh fails", async () => {
+    const persist = vi.fn();
+    const onUnauthorized = vi.fn();
+    apiClient.setAuthHandlers(
+      () => ({
+        userId: "user-1",
+        login: "owner",
+        email: "owner@test.local",
+        accessToken: "expired-token",
+        refreshToken: "refresh-token",
+        expiresAtUtc: "2999-01-01T00:00:00Z"
+      }),
+      persist
+    );
+    const unsubscribe = apiClient.onUnauthorized(onUnauthorized);
+
+    const fetchMock = vi.fn()
+      .mockResolvedValueOnce({ ok: false, status: 401, clone: () => ({ json: async () => ({ title: "expired" }) }), text: async () => "expired" })
+      .mockResolvedValueOnce({ ok: false, status: 401, clone: () => ({ json: async () => ({ title: "invalid refresh" }) }), text: async () => "invalid refresh" });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await expect(apiClient.getAccounts("expired-token")).rejects.toThrow();
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(persist).toHaveBeenCalledWith(null);
+    expect(onUnauthorized).toHaveBeenCalledTimes(1);
+    unsubscribe();
+  });
 });

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -39,6 +39,7 @@ type RequestOptions = {
   method?: string;
   body?: unknown;
   token?: string | null;
+  suppressNotification?: boolean;
 };
 
 type UnauthorizedListener = () => void;
@@ -75,7 +76,7 @@ async function request<T>(path: string, options: RequestOptions = {}, allowRefre
       }
     }
 
-    if (response.status === 401) {
+    if (response.status === 401 && !options.suppressNotification) {
       notifyUnauthorized();
     }
 
@@ -102,7 +103,8 @@ async function refreshSession(): Promise<AuthPayload | null> {
 
     refreshInFlight = request<AuthPayload>("/api/auth/refresh", {
       method: "POST",
-      body: { refreshToken: auth.refreshToken }
+      body: { refreshToken: auth.refreshToken },
+      suppressNotification: true
     }, false)
       .then((payload) => {
         persistAuth?.(payload);

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -42,14 +42,19 @@ type RequestOptions = {
 };
 
 type UnauthorizedListener = () => void;
+type AuthResolver = () => AuthPayload | null;
+type AuthPersister = (payload: AuthPayload | null) => void;
 
 const unauthorizedListeners = new Set<UnauthorizedListener>();
+let resolveAuth: AuthResolver | null = null;
+let persistAuth: AuthPersister | null = null;
+let refreshInFlight: Promise<AuthPayload | null> | null = null;
 
 function notifyUnauthorized() {
   unauthorizedListeners.forEach((listener) => listener());
 }
 
-async function request<T>(path: string, options: RequestOptions = {}): Promise<T> {
+async function request<T>(path: string, options: RequestOptions = {}, allowRefresh = true): Promise<T> {
   const response = await fetch(resolveApiUrl(API_BASE_URL, path), {
     method: options.method ?? "GET",
     headers: {
@@ -60,6 +65,16 @@ async function request<T>(path: string, options: RequestOptions = {}): Promise<T
   });
 
   if (!response.ok) {
+    if (response.status === 401 && allowRefresh && options.token && resolveAuth && persistAuth) {
+      const currentAuth = resolveAuth();
+      if (currentAuth && currentAuth.accessToken === options.token) {
+        const refreshed = await refreshSession();
+        if (refreshed?.accessToken && refreshed.accessToken !== options.token) {
+          return request<T>(path, { ...options, token: refreshed.accessToken }, false);
+        }
+      }
+    }
+
     if (response.status === 401) {
       notifyUnauthorized();
     }
@@ -72,6 +87,37 @@ async function request<T>(path: string, options: RequestOptions = {}): Promise<T
   }
 
   return response.json() as Promise<T>;
+}
+
+async function refreshSession(): Promise<AuthPayload | null> {
+  if (!resolveAuth || !persistAuth) {
+    return null;
+  }
+
+  if (!refreshInFlight) {
+    const auth = resolveAuth();
+    if (!auth?.refreshToken) {
+      return null;
+    }
+
+    refreshInFlight = request<AuthPayload>("/api/auth/refresh", {
+      method: "POST",
+      body: { refreshToken: auth.refreshToken }
+    }, false)
+      .then((payload) => {
+        persistAuth?.(payload);
+        return payload;
+      })
+      .catch(() => {
+        persistAuth?.(null);
+        return null;
+      })
+      .finally(() => {
+        refreshInFlight = null;
+      });
+  }
+
+  return refreshInFlight;
 }
 
 async function readErrorMessage(response: Response): Promise<string> {
@@ -99,6 +145,10 @@ async function readErrorMessage(response: Response): Promise<string> {
 }
 
 export const apiClient = {
+  setAuthHandlers(nextResolveAuth: AuthResolver | null, nextPersistAuth: AuthPersister | null) {
+    resolveAuth = nextResolveAuth;
+    persistAuth = nextPersistAuth;
+  },
   onUnauthorized(listener: UnauthorizedListener) {
     unauthorizedListeners.add(listener);
     return () => {
@@ -115,6 +165,12 @@ export const apiClient = {
     return request<AuthPayload>("/api/auth/login", {
       method: "POST",
       body: { login, password }
+    });
+  },
+  refresh(refreshToken: string) {
+    return request<AuthPayload>("/api/auth/refresh", {
+      method: "POST",
+      body: { refreshToken }
     });
   },
   getDashboard(token: string, month: string) {

--- a/frontend/src/state/AuthContext.test.tsx
+++ b/frontend/src/state/AuthContext.test.tsx
@@ -2,9 +2,13 @@ import { render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { AuthProvider, useAuth } from "./AuthContext";
 
+const onUnauthorizedMock = vi.fn();
+const setAuthHandlersMock = vi.fn();
+
 vi.mock("../api/client", () => ({
   apiClient: {
-    onUnauthorized: () => () => undefined,
+    onUnauthorized: onUnauthorizedMock,
+    setAuthHandlers: setAuthHandlersMock,
     login: vi.fn(),
     register: vi.fn()
   }
@@ -18,6 +22,9 @@ function AuthProbe() {
 describe("AuthProvider", () => {
   beforeEach(() => {
     window.localStorage.clear();
+    onUnauthorizedMock.mockReset();
+    setAuthHandlersMock.mockReset();
+    onUnauthorizedMock.mockReturnValue(() => undefined);
   });
 
   it("restores a valid persisted session from localStorage", async () => {
@@ -56,5 +63,27 @@ describe("AuthProvider", () => {
 
     await waitFor(() => expect(screen.getByText("anonymous")).toBeInTheDocument());
     expect(window.localStorage.getItem("ledgerra.auth")).toBeNull();
+  });
+
+  it("registers auth handlers and persists rotated auth payloads", async () => {
+    render(
+      <AuthProvider>
+        <AuthProbe />
+      </AuthProvider>
+    );
+
+    await waitFor(() => expect(setAuthHandlersMock).toHaveBeenCalled());
+    const persist = setAuthHandlersMock.mock.calls.at(-1)?.[1] as ((payload: unknown) => void);
+    persist({
+      userId: "user-1",
+      login: "owner",
+      email: "owner@ledgerra.local",
+      accessToken: "new-token",
+      refreshToken: "new-refresh",
+      expiresAtUtc: "2999-01-01T00:00:00Z"
+    });
+
+    await waitFor(() => expect(screen.getByText("authenticated")).toBeInTheDocument());
+    expect(window.localStorage.getItem("ledgerra.auth")).toContain("new-refresh");
   });
 });

--- a/frontend/src/state/AuthContext.test.tsx
+++ b/frontend/src/state/AuthContext.test.tsx
@@ -2,8 +2,10 @@ import { render, screen, waitFor } from "@testing-library/react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import { AuthProvider, useAuth } from "./AuthContext";
 
-const onUnauthorizedMock = vi.fn();
-const setAuthHandlersMock = vi.fn();
+const { onUnauthorizedMock, setAuthHandlersMock } = vi.hoisted(() => ({
+  onUnauthorizedMock: vi.fn(),
+  setAuthHandlersMock: vi.fn()
+}));
 
 vi.mock("../api/client", () => ({
   apiClient: {

--- a/frontend/src/state/AuthContext.tsx
+++ b/frontend/src/state/AuthContext.tsx
@@ -47,8 +47,6 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     }
   }, []);
 
-  useEffect(() => apiClient.onUnauthorized(() => persist(null)), []);
-
   const persist = (payload: AuthPayload | null) => {
     setAuth(payload);
     if (payload && isSessionValid(payload)) {
@@ -57,6 +55,15 @@ export function AuthProvider({ children }: { children: ReactNode }) {
       getAuthStorage().removeItem(STORAGE_KEY);
     }
   };
+
+  useEffect(() => {
+    apiClient.setAuthHandlers(() => auth, persist);
+    return () => {
+      apiClient.setAuthHandlers(null, null);
+    };
+  }, [auth]);
+
+  useEffect(() => apiClient.onUnauthorized(() => persist(null)), []);
 
   const login = async (login: string, password: string, mode: "login" | "register", email?: string) => {
     const payload = mode === "register"

--- a/frontend/tsconfig.app.json
+++ b/frontend/tsconfig.app.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
-    "target": "ES2020",
+    "target": "ES2022",
     "useDefineForClassFields": true,
-    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "lib": ["ES2022", "DOM", "DOM.Iterable"],
     "module": "ESNext",
     "skipLibCheck": true,
     "moduleResolution": "Node",


### PR DESCRIPTION
### Motivation
- The frontend currently drops the session on any 401 even though the backend supports refresh-token rotation, so requests should attempt a refresh and persist rotated tokens instead of immediately logging out.

### Description
- Added `apiClient.setAuthHandlers`, `apiClient.refresh`, and a `refreshSession` single-flight gate to dedupe concurrent refresh attempts and persist rotated `AuthPayload` via handlers.
- Enhanced the HTTP `request` path to attempt a single refresh+retry for authenticated 401 responses and to only notify unauthorized when refresh cannot recover the session.
- Wired `AuthContext` to register resolver/persist handlers with `apiClient` so rotated auth payloads are stored to localStorage and failed refreshes clear the session.
- Added unit tests that cover concurrent 401 handling, successful refresh with rotated tokens, failed refresh behavior, and AuthContext persistence wiring.

### Testing
- Added/updated tests in `frontend/src/api/client.test.ts` and `frontend/src/state/AuthContext.test.tsx` exercising refresh+retry, single-flight behavior, failed refresh handling, and persistence; these tests are included in the changes.
- Attempts to run the frontend tests in this environment (via `npm ci` / `npx vitest run` / `npm test`) failed due to registry/access restrictions (`npm` 403 and `vitest` unavailable), so automated tests could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a114a4403e48324971af43c735b4dc7)